### PR TITLE
fix various docs errors

### DIFF
--- a/docs/Component.md
+++ b/docs/Component.md
@@ -71,7 +71,7 @@ Public properties can be set on page load by an optional ```mount()``` method or
             >
                 <arguments>
                     <argument name="magewire" xsi:type="array">
-                        <item name="type">\My\Module\Magewire\Explanation</item>
+                        <item name="type" xsi:type="object">\My\Module\Magewire\Explanation</item>
                         <item name="foo" xsi:type="string">bar</item>
                     </argument>
                 </arguments>

--- a/docs/Component.md
+++ b/docs/Component.md
@@ -7,7 +7,7 @@
 
 namespace My\Module\Magewire;
 
-use Magewirephp\Magewire\Livewire\Component;
+use Magewirephp\Magewire\Component;
 
 class Explanation extends Component
 {

--- a/docs/Component.md
+++ b/docs/Component.md
@@ -5,7 +5,7 @@
 ```php
 <?php declare(strict_types=1);
 
-namespace My\Module\Livewire;
+namespace My\Module\Magewire;
 
 use Magewirephp\Magewire\Livewire\Component;
 


### PR DESCRIPTION
Hello,

three little fixes to the docs:

1. The namespace was still `Livewire`
2. The using still contained `Livewire`
3. The item was missing a mandatory type definition.