### PR TITLE
check for a setter method 'set[PropertyName]' when property is hydrated

### DIFF
--- a/src/Model/Hydrator/Property.php
+++ b/src/Model/Hydrator/Property.php
@@ -56,7 +56,7 @@ class Property implements HydratorInterface
         // Bind regular properties.
         $this->propertyHelper->assign(function (Component $component, $request, $property, $value) {
             $setter = 'set' . ucfirst($property);
-            (method_exists($component,$setter))?$component->$setter($value):$component->{$property} = $value;
+            (method_exists($component, $setter))?$component->$setter($value):$component->{$property} = $value;
         }, $request, $component);
 
         // Flush properties cache.

--- a/src/Model/Hydrator/Property.php
+++ b/src/Model/Hydrator/Property.php
@@ -55,7 +55,8 @@ class Property implements HydratorInterface
 
         // Bind regular properties.
         $this->propertyHelper->assign(function (Component $component, $request, $property, $value) {
-            $component->{$property} = $value;
+            $setter = 'set' . ucfirst($property);
+            (method_exists($component,$setter))?$component->$setter($value):$component->{$property} = $value;
         }, $request, $component);
 
         // Flush properties cache.


### PR DESCRIPTION
If the code that sets a property checks for existence of a setter method in component class, one can inject logic at the time of setting the property at hydration.

Usage case:

Building a custom pagination component, the current category is added as a queryString to be populated with hydration.

```
class Pagination extends Component\Pagination
{
    public $currentCategory;

    protected $queryString = [
        'page',
        'pageSize',
        'currentCategory'
    ];
```

This works fine, and the currentCategory property is 100% populated on pagination clicks, however, when one tries to load the current product collection, the current layer will default to root category.

```
public function getAllPageItems(): array
    {
        return $this->listProduct->getLoadedProductCollection()->getItems();
    }
```
which end up on 

Magento\Catalog\Block\Product\ListProduct

```
/**
     * Retrieve loaded category collection
     *
     * @return AbstractCollection
     */
    public function getLoadedProductCollection()
    {
        $collection = $this->_getProductCollection();

        $categoryId = $this->getLayer()->getCurrentCategory()->getId();
        foreach ($collection as $product) {
            $product->setData('category_id', $categoryId);
        }

        return $collection;
    }
```

```
$categoryId = $this->getLayer()->getCurrentCategory()->getId();
```

will result to the default root category

so, by using a setter in the Pagination class, which is called instead of placing the property directly, one can add logic to re-populate the base layout category.

in pagination component class:

```
 public function setCurrentCategory($value) {
        $this->currentCategory = (int)$value;
        $this->listProduct->getLayer()->setCurrentCategory((int)$value);
    }
```

The ability to simply intercept property hydration via a setter metod can have other usage case benefits, and not require unneeded plugins/code extending.

This does however place the responsibility to populate the property with the developer making the code. I think that is ok, and would be expected, when placing the setter method. 

![image](https://user-images.githubusercontent.com/4994260/146628719-ed25a7c1-7b4a-4774-bc29-967ae102dba7.png)

