### PR TITLE
[bugfix/form-property-types]:+ Removed the property types

### DIFF
--- a/src/Component/Form.php
+++ b/src/Component/Form.php
@@ -17,21 +17,21 @@ abstract class Form extends Component
     public const COMPONENT_TYPE = 'form';
 
     /** @var Validator $validator */
-    protected Validator $validator;
+    protected $validator;
 
     /**
      * Validation rules.
      *
      * @var array
      */
-    protected array $rules = [];
+    protected $rules = [];
 
     /**
      * Validation messages.
      *
      * @var array
      */
-    protected array $messages = [];
+    protected $messages = [];
 
     /**
      * @param Validator $validator


### PR DESCRIPTION
Will return in Magewire v2.x.x where everyone need to upgrade their components.