### PR TITLE
Fix PHP 8.1 error

### DIFF
--- a/src/Component/Form.php
+++ b/src/Component/Form.php
@@ -26,7 +26,7 @@ abstract class Form extends Component
      *
      * @var array
      */
-    protected $rules = [];
+    protected array $rules = [];
 
     /**
      * Validation messages.


### PR DESCRIPTION
The type of the `$rules` array in the Hyvä Checkout is stricter than the array here. So adding the type hint fixes the following error;

```
Fatal error: Type of Hyva\CheckoutDefault\Magewire\Component\Checkout\AddressForm::$rules must not be defined (as in class Magewirephp\Magewire\Component\Form) in vendor/hyva-themes/checkout-default/src/Magewire/Component/Checkout/AddressForm.php on line 36
```