### PR TITLE
Docs: Fix Component-Based Restricted Methods Definition

### DIFF
--- a/docs/Features.md
+++ b/docs/Features.md
@@ -579,7 +579,7 @@ inside the phtml template only. It's not a best practice and you should use a Vi
 ```php
 class Explanation extends \Magewirephp\Magewire\Component
 {
-    private $uncallables = ['myCustomSetMethod'];
+    protected array $uncallables = ['myCustomSetMethod'];
 }
 ```
 


### PR DESCRIPTION
## Description
- Updates the `Restricted Public Methods` feature documentation to reflect the current state of the [`Magewirephp\Magewire\Model\Concern\Method` trait's `$uncallables` property](https://github.com/magewirephp/magewire/blob/main/src/Model/Concern/Method.php#L19)
