### PR TITLE
fix: type annotations for dispatchBrowserEvent

### DIFF
--- a/src/Model/Concern/BrowserEvent.php
+++ b/src/Model/Concern/BrowserEvent.php
@@ -22,7 +22,7 @@ trait BrowserEvent
 
     /**
      * @param $event
-     * @param null $data
+     * @param mixed|null $data
      */
     public function dispatchBrowserEvent($event, $data = null): void
     {


### PR DESCRIPTION
Our linter failed because we passed an array of data into the method instead of `null` - since only ever passing `null` to the method does not make sense but the type can really be anything this should be `mixed` instead.