### PR TITLE
Enforce lowercase layout handle names

### DIFF
--- a/src/Controller/Post/Livewire.php
+++ b/src/Controller/Post/Livewire.php
@@ -139,7 +139,7 @@ class Livewire implements HttpPostActionInterface, CsrfAwareActionInterface
     public function locateWireComponent(array $post): BlockInterface
     {
         $page = $this->resultPageFactory->create();
-        $page->addHandle($post['fingerprint']['handle'])->initLayout();
+        $page->addHandle(strtolower($post['fingerprint']['handle']))->initLayout();
 
         $this->eventManager->dispatch('locate_wire_component_before', [
             'post' => $post, 'page' => $page


### PR DESCRIPTION
Magento always lowercases all parts of the request path when building the action layout handle name. For example, a request to `foo/Bar/Baz` will load an action handle `foo_bar_baz`.

The `$post['fingerprint']['handle']` value contains a not lowercased version of the handle, as returned by `$request->getFullActionName()` (see `\Magewirephp\Magewire\Model\ComponentManager::createInitialRequest`).

Because of this discrepancy, loading a page using a path with some capital letters shows the page during the preceding request, but for subsequent requests an error `{"message":"Magewire component \"the-component-name\" could not be found","code":500}` is shown.

This PR applies the same lower-case normalization to the handle in subsequent requests as Magento does during the preceding request.