### PR TITLE
fix issue where public property values are restored to default value

### DIFF
--- a/src/Model/Hydrator/Property.php
+++ b/src/Model/Hydrator/Property.php
@@ -44,7 +44,7 @@ class Property implements HydratorInterface
     public function hydrate(Component $component, RequestInterface $request): void
     {
         if ($request->isSubsequent()) {
-            $overwrite = array_replace_recursive($request->getServerMemo('data'), $component->getPublicProperties());
+            $overwrite = array_replace_recursive($component->getPublicProperties(), $request->getServerMemo('data'));
         }
 
         $this->propertyHelper->assign(function (Component $component, $property, $value) {


### PR DESCRIPTION
We ran into this issue during yesterdays hackathon. It seems like the arguments passed to array_merge_recursive should be switched. I the old situation the default values are assigned to the $overwrite variable for non array value and array keys existing in the default value on array properties. This fixed the issue for me.