### PR TITLE
Fix 'Alpine is not defined' errors triggered by third party scripts

### DIFF
--- a/src/view/frontend/templates/page/js/magewire-livewire.phtml
+++ b/src/view/frontend/templates/page/js/magewire-livewire.phtml
@@ -28,7 +28,7 @@ $magewireScripts = $block->getViewModel();
         const orig = Element.prototype.setAttribute;
         Element.prototype.setAttribute = function patchLivewireSetAttribute(name, value) {
             // In Alpine v2, ignore Alpine v3 x-bind attributes that are used as x-spread
-            if (Alpine && Alpine.version.substring(0, 1) === '2' && ! name) return;
+            if (window.Alpine && Alpine.version.substring(0, 1) === '2' && ! name) return;
             orig.call(this, name, value);
         }
     })


### PR DESCRIPTION
This `Alpine is not defined` error can only happen if some external script using `setAttribute` is loaded and evaluated before  `Alpine` is loaded.  
This fix will take care of the issue, as `window.Alpine` will evaluate to `undefined` before alpine.js is loaded.