### PR TITLE
Fix loader issues

### DIFF
--- a/src/view/frontend/templates/html/loader/notifications/messenger.phtml
+++ b/src/view/frontend/templates/html/loader/notifications/messenger.phtml
@@ -20,8 +20,9 @@ use Magewirephp\Magewire\Model\Action\FireEvent;
 <div class="magewire.messenger z-50 w-full fixed top-0 right-0 md:max-w-xs">
     <div class="space-y-6 flex flex-col space-y-3 px-3 md:flex-col-reverse">
         <template x-for="(message, index, messages) in messageList()" x-bind:key="index">
-            <button class="magewire.notification.message relative"
-                    x-bind:class="{
+            <div role="button" aria-busy="true" aria-label="off"
+                 class="magewire.notification.message relative"
+                   x-bind:class="{
                         'sync-input' : message.update.type === '<?= /** @noEscape */ SyncInput::ACTION ?>',
                         'call-method': message.update.type === '<?= /** @noEscape */ CallMethod::ACTION ?>',
                         'fire-event' : message.update.type === '<?= /** @noEscape */ FireEvent::ACTION ?>',
@@ -34,11 +35,11 @@ use Magewirephp\Magewire\Model\Action\FireEvent;
                     x-transition:leave-end="opacity-0 scale-80"
                     x-show="message.active"
                     x-on:click.once="message.active = false"
-                    x-bind:diabled="message.loading"
+                    x-bind:disabled="message.loading"
             >
                 <div class="relative w-full
                             rounded-md border border-gray-300
-                            bg-white bg-opacity-[75%] backdrop-blur-sm bg-blur
+                            bg-white bg-opacity-75 backdrop-blur-sm bg-blur
                             py-3 px-5 md:py-4 md:pl-6 md:pr-4
                             shadow-lg
                             md:max-w-sm"
@@ -109,7 +110,7 @@ use Magewirephp\Magewire\Model\Action\FireEvent;
                         </div>
                     </div>
                 </div>
-            </button>
+            </div>
         </template>
     </div>
 </div>

--- a/src/view/frontend/templates/html/loader/notifications/messenger.phtml
+++ b/src/view/frontend/templates/html/loader/notifications/messenger.phtml
@@ -20,22 +20,23 @@ use Magewirephp\Magewire\Model\Action\FireEvent;
 <div class="magewire.messenger z-50 w-full fixed top-0 right-0 md:max-w-xs">
     <div class="space-y-6 flex flex-col space-y-3 px-3 md:flex-col-reverse">
         <template x-for="(message, index, messages) in messageList()" x-bind:key="index">
-            <div role="button" aria-busy="true" aria-label="off"
+            <div role="button"
+                 aria-busy="true"
+                 aria-label="off"
                  class="magewire.notification.message relative"
-                   x-bind:class="{
-                        'sync-input' : message.update.type === '<?= /** @noEscape */ SyncInput::ACTION ?>',
-                        'call-method': message.update.type === '<?= /** @noEscape */ CallMethod::ACTION ?>',
-                        'fire-event' : message.update.type === '<?= /** @noEscape */ FireEvent::ACTION ?>',
+                 x-bind:class="{
+                     'sync-input' : message.update.type === '<?= /** @noEscape */ SyncInput::ACTION ?>',
+                     'call-method': message.update.type === '<?= /** @noEscape */ CallMethod::ACTION ?>',
+                     'fire-event' : message.update.type === '<?= /** @noEscape */ FireEvent::ACTION ?>',
 
-                        'message-failure': message.success === false,
-                        'message-success': message.success === true,
-                        'cursor-not-allowed opacity-25': message.loading === true
-                    }"
-                    x-transition:leave="transition ease-in duration-600"
-                    x-transition:leave-start="opacity-100 scale-100"
-                    x-transition:leave-end="opacity-0 scale-80"
-                    x-show="message.active"
-                    x-on:click.once="if (!message.loading) message.active = false"
+                     'message-failure': message.success === false,
+                     'message-success': message.success === true
+                 }"
+                 x-transition:leave="transition ease-in duration-600"
+                 x-transition:leave-start="opacity-100 scale-100"
+                 x-transition:leave-end="opacity-0 scale-80"
+                 x-show="message.active"
+                 x-on:click.once="message.active = false"
             >
                 <div class="relative w-full
                             rounded-md border border-gray-300

--- a/src/view/frontend/templates/html/loader/notifications/messenger.phtml
+++ b/src/view/frontend/templates/html/loader/notifications/messenger.phtml
@@ -28,14 +28,14 @@ use Magewirephp\Magewire\Model\Action\FireEvent;
                         'fire-event' : message.update.type === '<?= /** @noEscape */ FireEvent::ACTION ?>',
 
                         'message-failure': message.success === false,
-                        'message-success': message.success === true
+                        'message-success': message.success === true,
+                        'cursor-not-allowed opacity-25': message.loading === true
                     }"
                     x-transition:leave="transition ease-in duration-600"
                     x-transition:leave-start="opacity-100 scale-100"
                     x-transition:leave-end="opacity-0 scale-80"
                     x-show="message.active"
-                    x-on:click.once="message.active = false"
-                    x-bind:disabled="message.loading"
+                    x-on:click.once="if (!message.loading) message.active = false"
             >
                 <div class="relative w-full
                             rounded-md border border-gray-300


### PR DESCRIPTION
This MR fixes a number of issues with the loader:

* Fix use of invalid elements inside `<button>`.  
  See “Content model” in [the button specs](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element), so “[Phrasing content](https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2), but there must be no [interactive content](https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2) descendant and no descendant with the tabindex attribute specified.”
* Replace `x-bind:diabled="message.loading"` with alternative implementation that is applicable to `div` elements.
* Fix a11y notifications with screen readers
* Prefer [standard Tailwindcss class](https://tailwindcss.com/docs/opacity) `bg-opacity-75` over custom value class `bg-opacity-[75%]` (to help keep styles.css size in check)