### PR TITLE
Allow passing an assoc as an emit param

### DIFF
--- a/src/Model/Action/CallMethod.php
+++ b/src/Model/Action/CallMethod.php
@@ -39,10 +39,10 @@ class CallMethod implements ActionInterface
         // Magic or not, it's still a class method who can have no '$' as name prefix.
         $method = ltrim($payload['method'], '$');
         // Let's make sure we have an un-packable array.
-        $params = is_array($payload['params']) ? $payload['params'] : [$payload['params']];
+        $params = is_array($payload['params']) && isset($payload['params'][0]) ? array_values($payload['params']) : [$payload['params']];
 
         if ($this->isCallable($method, $component)) {
-            return $component->{$method}(...array_values($params));
+            return $component->{$method}(...$params);
         }
 
         // Determine the required type class by method in specific order.
@@ -51,7 +51,7 @@ class CallMethod implements ActionInterface
         $params[] = $component;
 
         if ($this->isCallable($method, $type)) {
-            return $type->{$method}(...array_values($params));
+            return $type->{$method}(...$params);
         }
 
         throw new ComponentActionException(__('Method %1 does not exist or can not be called', [$method]));

--- a/src/Model/Element/Event.php
+++ b/src/Model/Element/Event.php
@@ -53,7 +53,8 @@ class Event
     {
         $output = [
             'event'  => $this->name,
-            'params' => array_values($this->params),
+            // Ensure params is a numeric indexed array. If it is an assoc, wrap it.
+            'params' => isset($this->params[0]) ? array_values($this->params) : [$this->params],
         ];
 
         if ($this->up) {


### PR DESCRIPTION
Allow passing PHP assocs as arguments to emit messages.

Currently, when a messages is emitted like this:
```php
$this->emit('foo_bar', ['is_complete' => true]);
```

And another component listen to it, like
```php
    public $listeners = [
        'foo_bar' => 'doSomething',
    ];
```

The `doSomething` methods receives a single argument `true`.

Passing the argument as a nested array produces an identical result:
```php
$this->emit('foo_bar', [['is_complete' => true]]);
```

To pass an assoc, it hase to nest it even deeper:

```php
$this->emit('foo_bar', [[['is_complete' => true]]]);
```

This behavior is unexpected. With the changes in this PR, passing an assoc as an argument works.