### PR TITLE
Fix property-on-null error

### DIFF
--- a/src/view/frontend/templates/html/loader/notifications/bindings.phtml
+++ b/src/view/frontend/templates/html/loader/notifications/bindings.phtml
@@ -17,13 +17,13 @@
 
                 <?php /* @see Magewirephp_Magewire::page/js/magewire/plugin/loader.phtml */ ?>
                 document.addEventListener('magewire:loader:stop', (event) => {
-                    if (! event.detail.component && ! event.detail.component.id && event.detail.loader) {
+                    if ((! event.detail) || (! event.detail.component) || (! event.detail.component.id) || (! event.detail.loader)) {
                         return;
                     }
 
                     <?php /* Find the component by its unique key to try and deactivate it. */ ?>
                     for (let message in this.messages) {
-                        if (event.detail.loader && this.messages[message].key == event.detail.loader.key) {
+                        if (this.messages[message].key == event.detail.loader.key) {
                             return this.messageDeactivate(message, event.failure || false);
                         }
                     }


### PR DESCRIPTION
The `magewire:loader:stop` does not always have the `details` property set.`  
This PR fixes the guard clause to take this into account, and also avoids evaluation of properties if the given parent property is not defined.


<img width="523" alt="Bildschirmfoto 2023-06-07 um 10 04 17" src="https://github.com/magewirephp/magewire/assets/72463/39b2af3a-7af8-485a-bc92-9d41604b00c7">

