### PR TITLE
Emit param handling: allow assoc arrays and multiple emit arguments (like Livewire)

### DIFF
--- a/src/Model/Action/CallMethod.php
+++ b/src/Model/Action/CallMethod.php
@@ -39,10 +39,12 @@ class CallMethod extends Action
         // Magic or not, it's still a class method who can have no '$' as name prefix.
         $method = ltrim($payload['method'], '$');
         // Let's make sure we have an un-packable array.
-        $params = is_array($payload['params']) ? $payload['params'] : [$payload['params']];
+        $params = is_array($payload['params']) && (isset($payload['params'][0]) || empty($payload['params']))
+            ? array_values($payload['params'])
+            : [$payload['params']];
 
         if ($this->isCallable($method, $component)) {
-            return $component->{$method}(...array_values($params));
+            return $component->{$method}(...$params);
         }
 
         // Determine the required type class by method in specific order.
@@ -51,7 +53,7 @@ class CallMethod extends Action
         $params[] = $component;
 
         if ($this->isCallable($method, $type)) {
-            return $type->{$method}(...array_values($params));
+            return $type->{$method}(...$params);
         }
 
         throw new ComponentActionException(__('Method %1 does not exist or can not be called', [$method]));

--- a/src/Model/Action/CallMethod.php
+++ b/src/Model/Action/CallMethod.php
@@ -38,10 +38,15 @@ class CallMethod extends Action
     {
         // Magic or not, it's still a class method who can have no '$' as name prefix.
         $method = ltrim($payload['method'], '$');
-        // Let's make sure we have an un-packable array.
-        $params = is_array($payload['params']) && (isset($payload['params'][0]) || empty($payload['params']))
-            ? array_values($payload['params'])
-            : [$payload['params']];
+
+        // Check if it is a numerically indexed array or otherwise.
+        if (is_array($payload['params']) && (isset($payload['params'][0]) || empty($payload['params']))) {
+            // Numerically indexed array. Ensure the keys are consecutive, so they are passed as multiple args.
+            $params = array_values($payload['params']);
+        } else {
+            // Assoc or non-array, pass as single argument.
+            $params = [$payload['params']];
+        }
 
         if ($this->isCallable($method, $component)) {
             return $component->{$method}(...$params);

--- a/src/Model/Action/FireEvent.php
+++ b/src/Model/Action/FireEvent.php
@@ -37,9 +37,14 @@ class FireEvent extends Action
     {
         $listeners  = $this->listenerHydrator->assimilateListeners($component);
         $method     = $listeners[$payload['event']] ?? false;
-        $parameters = is_array($payload['params']) && count($payload['params']) > 1
-            ? $payload['params']
-            : $payload['params'][0] ?? [];
+        // Support the different emit argument styles
+        if (is_array($payload['params']) && count($payload['params']) > 1) {
+            // Multiple arguments, e.g. emit('foo', 'bar', 'baz') or emit('foo', ['bar', 'baz'])
+            $parameters = $payload['params'];
+        } else {
+            // None or single parameter, e.g. emit('foo') or emit('foo', ['bar' => 'baz'])
+            $parameters = $payload['params'][0] ?? [];
+        }
 
         if ($method === false) {
             throw new ComponentActionException(__('Method does not exist or can not be called'));

--- a/src/Model/Action/FireEvent.php
+++ b/src/Model/Action/FireEvent.php
@@ -37,7 +37,9 @@ class FireEvent extends Action
     {
         $listeners  = $this->listenerHydrator->assimilateListeners($component);
         $method     = $listeners[$payload['event']] ?? false;
-        $parameters = $payload['params'][0] ?? [];
+        $parameters = is_array($payload['params']) && count($payload['params']) > 1
+            ? $payload['params']
+            : $payload['params'][0] ?? [];
 
         if ($method === false) {
             throw new ComponentActionException(__('Method does not exist or can not be called'));

--- a/src/Model/Concern/Emit.php
+++ b/src/Model/Concern/Emit.php
@@ -101,12 +101,12 @@ trait Emit
     /**
      * Support legacy emits until major update.
      */
-    protected function supportLegacySyntax($firstArgs, $restArgs): array
+    protected function supportLegacySyntax($firstArg, $restArgs): array
     {
-        if (! is_array($firstArgs) || count($restArgs) > 1) {
+        if (! is_array($firstArg) || count($restArgs) > 1) {
             return $restArgs;
         }
 
-        return $firstArgs;
+        return is_array($firstArg) && empty($firstArg) ? [] : [$firstArg];
     }
 }

--- a/src/Model/Concern/Emit.php
+++ b/src/Model/Concern/Emit.php
@@ -99,14 +99,23 @@ trait Emit
     }
 
     /**
+     * Returns the specified arguments as params array matching livewires behavior.
+     *
      * Support legacy emits until major update.
      */
     protected function supportLegacySyntax($firstArg, $restArgs): array
     {
+        // e.g. emit('test', 'foo') or emit('test', 'foo', 'bar')
         if (! is_array($firstArg) || count($restArgs) > 1) {
             return $restArgs;
         }
 
-        return is_array($firstArg) && empty($firstArg) ? [] : [$firstArg];
+        // e.g. emit('test')
+        if (empty($firstArg)) {
+            return [];
+        }
+
+        // e.g. emit('test', ['foo', 'bar'])
+        return [$firstArg];
     }
 }

--- a/src/Model/Element/Event.php
+++ b/src/Model/Element/Event.php
@@ -53,7 +53,7 @@ class Event
     {
         $output = [
             'event'  => $this->name,
-            'params' => empty($this->params) ? [] : $this->params
+            'params' => $this->params
         ];
 
         if ($this->up) {

--- a/src/Model/Element/Event.php
+++ b/src/Model/Element/Event.php
@@ -53,7 +53,7 @@ class Event
     {
         $output = [
             'event'  => $this->name,
-            'params' => array_values($this->params),
+            'params' => empty($this->params) ? [] : $this->params
         ];
 
         if ($this->up) {


### PR DESCRIPTION
The PR https://github.com/magewirephp/magewire/pull/104 caused an issue where an empty array is passed as an argument to emits when no arguments where specified.  
The changes in this PR resolve the problem.