### PR TITLE
Fix loader clearing

### DIFF
--- a/src/view/frontend/templates/html/loader/notifications/bindings.phtml
+++ b/src/view/frontend/templates/html/loader/notifications/bindings.phtml
@@ -55,7 +55,7 @@
                 }
 
                 if (failure) {
-                    message.timeout =+ 5000;
+                    message.timeout += 5000;
                 }
 
                 message.loading = false;

--- a/src/view/frontend/templates/page/js/magewire/plugin/loader.phtml
+++ b/src/view/frontend/templates/page/js/magewire/plugin/loader.phtml
@@ -125,10 +125,6 @@ $magewireScripts = $block->getViewModel();
                 });
             }
 
-            const getLoaderIndex = function() {
-                return queue.findLastIndex(item => item.loader)
-            }
-
             const stop = function(component, failure = false, force = false) {
                 if (failure) {
                     force = true;
@@ -145,14 +141,8 @@ $magewireScripts = $block->getViewModel();
 
                 if (force) {
                     remove.push(me);
-                } else {
-                    const loader = getLoaderIndex();
-
-                    if (loader === -1 && queue.some(item => item && item.done)) {
-                        remove = Object.keys(queue);
-                    } else if (loader >= 0 && queue[loader].done) {
-                        remove = Object.keys(queue);
-                    }
+                } else if (queue.every(item => item && item.done)) {
+                    remove = Object.keys(queue);
                 }
 
                 <?php /* Run over the queue and remove those who are marked. In the meanwhile, when we hit
@@ -167,6 +157,7 @@ $magewireScripts = $block->getViewModel();
                             }
                         });
                     }
+
                     delete queue[index];
                 });
 

--- a/src/view/frontend/templates/page/js/magewire/plugin/loader.phtml
+++ b/src/view/frontend/templates/page/js/magewire/plugin/loader.phtml
@@ -126,7 +126,7 @@ $magewireScripts = $block->getViewModel();
             }
 
             const getLoaderIndex = function() {
-                return [...queue].reverse().findIndex(item => item.loader);
+                return queue.findLastIndex(item => item.loader)
             }
 
             const stop = function(component, failure = false, force = false) {
@@ -137,7 +137,7 @@ $magewireScripts = $block->getViewModel();
                 <?php /* Queue items targeted to remove. */ ?>
                 let remove = [];
                 <?php /* Get my own index. */ ?>
-                let me = queue.findIndex(item => item && item.component && item.component.id === component.id);
+                const me = queue.findIndex(item => item && item.component && item.component.id === component.id);
 
                 if (queue[me]) {
                     queue[me].done = true;
@@ -146,9 +146,9 @@ $magewireScripts = $block->getViewModel();
                 if (force) {
                     remove.push(me);
                 } else {
-                    let loader = getLoaderIndex();
+                    const loader = getLoaderIndex();
 
-                    if (loader === -1 && queue.some(item => item.done)) {
+                    if (loader === -1 && queue.some(item => item && item.done)) {
                         remove = Object.keys(queue);
                     } else if (loader >= 0 && queue[loader].done) {
                         remove = Object.keys(queue);
@@ -156,21 +156,18 @@ $magewireScripts = $block->getViewModel();
                 }
 
                 <?php /* Run over the queue and remove those who are marked. In the meanwhile, when we hit
-                         a item which seems to have a loader, it should stop itself. */ ?>
+                         an item which seems to have a loader, it should stop itself. */ ?>
                 remove.forEach(index => {
-                    if (queue[index]) {
-                        if (queue[index].loader) {
-                            Magewire.dispatchEvent(`loader:stop`, {
-                                detail: {
-                                    loader: queue[index].loader,
-                                    component: queue[index].component,
-                                    failure: failure
-                                }
-                            });
-                        }
-
-                        delete queue[index];
+                    if (queue[index] && queue[index].loader) {
+                        Magewire.dispatchEvent(`loader:stop`, {
+                            detail: {
+                                loader: queue[index].loader,
+                                component: queue[index].component,
+                                failure: failure
+                            }
+                        });
                     }
+                    delete queue[index];
                 });
 
                 if (Object.values(queue).length === 0) {


### PR DESCRIPTION
Refactor `getLoaderIndex` to return the last loader `item.loader` index based on the regular queue order (without reversing the array before searching).

This in turn allows accessing the queue with the `loader` index to check `queue[loader].done`.