### PR TITLE
Validate fingerprint handle

### DIFF
--- a/src/Model/Component/Resolver/Layout.php
+++ b/src/Model/Component/Resolver/Layout.php
@@ -28,6 +28,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  */
 class Layout implements ResolverInterface
 {
+    public const ELEMENT_NAME_TYPE_PATTERN = '/^[a-zA-Z0-9][a-zA-Z\d\-_\.]*$/';
+
     protected ResultPageFactory $resultPageFactory;
     protected EventManagerInterface $eventManager;
     protected ComponentFactory $componentFactory;
@@ -85,7 +87,11 @@ class Layout implements ResolverInterface
     public function reconstruct(RequestInterface $request): Component
     {
         $page = $this->resultPageFactory->create();
-        $page->addHandle(strtolower($request->getFingerprint('handle')))->initLayout();
+        $handleName = $request->getFingerprint('handle');
+        if (preg_match(self::ELEMENT_NAME_TYPE_PATTERN, $handleName) !== 1) {
+            throw new HttpException(400, sprintf('Magewire component has invalid handle "%s"', $handleName));
+        }
+        $page->addHandle(strtolower($handleName))->initLayout();
 
         /**
          * @deprecated this code is no longer supported and may cause issues if used.


### PR DESCRIPTION
The validation regex is the same as that of the `elementNameType` type that can be found in `vendor/magento/framework/View/Layout/etc/elements.xsd`, which is used as the type of the `id` attribute for the `handle` element in `vendor/magento/framework/View/Layout/etc/layout_merged.xsd`.