### PR TITLE
Remove dep with symfony/http-kernel

### DIFF
--- a/src/Controller/Post/Livewire.php
+++ b/src/Controller/Post/Livewire.php
@@ -9,6 +9,7 @@
 namespace Magewirephp\Magewire\Controller\Post;
 
 use Exception;
+use RuntimeException;
 use Laminas\Http\AbstractMessage;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -32,7 +33,6 @@ use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Serialize\SerializerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Livewire implements HttpPostActionInterface, CsrfAwareActionInterface, MagewireSubsequentActionInterface
 {
@@ -71,7 +71,7 @@ class Livewire implements HttpPostActionInterface, CsrfAwareActionInterface, Mag
             try {
                 $request = $this->httpFactory->createRequest($this->request->getParams())->isSubsequent(true);
             } catch (LocalizedException $exception) {
-                throw new HttpException(400);
+                throw new RuntimeException(400);
             }
 
             $component = $this->locateWireComponent($request);


### PR DESCRIPTION
As mentioned in https://github.com/magewirephp/magewire/pull/107 there is an undocumented dependency with `symfony/http-kernel` only for an exception that is thrown. The `HttpException` (https://github.com/symfony/http-kernel/blob/6.3/Exception/HttpException.php) actually inherits from `\RuntimeException`. This PR simply just removes the dep and throws the `RuntimeException` as is. Nothing fancy.

Additional comment, the reason why this issue got started is that the `symfony/http-foundation` package (which is a requirement for Magewire) has a `require-dev` dep with `symfony/http-kernel` (https://github.com/symfony/http-foundation/blob/6.3/composer.json#L29). If composer is installed in dev env, then this problem does not occur.