### PR TITLE
V1: Feature: Add End 2 End tests

### DIFF
--- a/.github/workflows/end-2-end.yml
+++ b/.github/workflows/end-2-end.yml
@@ -1,0 +1,71 @@
+name: End 2 End Tests
+on: [push, pull_request]
+
+jobs:
+  end-2-end-tests:
+    strategy:
+      matrix:
+        include:
+          - PHP_VERSION: php74-fpm
+            MAGENTO_VERSION: 2.4.3
+          - PHP_VERSION: php81-fpm
+            MAGENTO_VERSION: 2.4.6
+          - PHP_VERSION: php82-fpm
+            MAGENTO_VERSION: 2.4.6
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+
+        - name: Start Docker
+          run: docker run --detach -p 8080:80 --name magento-project-community-edition michielgerritsen/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+
+        - name: Change the version in composer.json so we can install the examples
+          run: |
+            sed -i -E 's/"version": "[0-9]+\.[0-9]+\.[0-9]+"/"version": "1.99.0"/' composer.json
+
+        - name: Install Hyvä & prepare Magento
+          run: |
+                docker exec magento-project-community-edition sh -c "mkdir -p ~/.ssh/ && echo \"${{ secrets.SSH_PRIVATE_KEY }}\" > ~/.ssh/id_ed25519"
+                docker exec magento-project-community-edition sh -c "chmod 700 ~/.ssh && chmod 600 ~/.ssh/id_ed25519"
+                docker exec magento-project-community-edition sh -c "ssh-keyscan -t rsa gitlab.hyva.io >> ~/.ssh/known_hosts"
+                docker exec magento-project-community-edition ./retry "composer config repositories.hyva-themes/magento2-theme-module git git@gitlab.hyva.io:hyva-themes/magento2-theme-module.git && composer config repositories.hyva-themes/magento2-reset-theme git git@gitlab.hyva.io:hyva-themes/magento2-reset-theme.git && composer config repositories.hyva-themes/magento2-email-module git git@gitlab.hyva.io:hyva-themes/magento2-email-module.git && composer config repositories.hyva-themes/magento2-default-theme git git@gitlab.hyva.io:hyva-themes/magento2-default-theme.git"
+                docker exec magento-project-community-edition ./retry "composer require hyva-themes/magento2-default-theme"
+                docker exec magento-project-community-edition ./retry "bin/magento setup:upgrade"
+                
+                HYVA_ID=$(docker exec magento-project-community-edition sh -c "magerun2 dev:theme:list --format=json --skip-root-check | jq -r '.[] | select(.code == \"Hyva\\/default\") | .id'")
+                echo "Hyvä has theme ID $HYVA_ID"
+                docker exec magento-project-community-edition ./retry "magerun2 config:store:set design/theme/theme_id $HYVA_ID --scope=stores --scope-id=1"
+                docker exec magento-project-community-edition /bin/bash ./change-base-url http://localhost:8080/
+                docker exec magento-project-community-edition ./retry "bin/magento cache:flush"
+
+        - name: Upload the code into the docker container
+          run: |
+                docker cp $(pwd) magento-project-community-edition:/data/extensions/
+                docker exec magento-project-community-edition composer require --no-plugins --no-interaction magewirephp/magewire:@dev magewirephp/magewire-examples
+                docker exec magento-project-community-edition ./retry "bin/magento setup:upgrade"
+                docker exec magento-project-community-edition ./retry "bin/magento cache:flush"
+
+        - name: Check webserver
+          run: curl --fail-with-body -vvv http://localhost:8080
+
+        - name: Install Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version: 18
+
+        - name: Install dependencies
+          run: npm ci
+
+        - name: Install Playwright Browsers
+          run: npx playwright install --with-deps
+
+        - name: Run Playwright tests
+          run: BASE_URL=http://localhost:8080/ npx playwright test
+
+        - uses: actions/upload-artifact@v2
+          if: always()
+          with:
+            name: playwright-report
+            path: playwright-report/
+            retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 **/.DS_Store
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ to learn more and start making your Magento 2 store more dynamic and engaging to
 - [More about Hydrators](./docs/Hydrators.md)
 - [Developer Tools](./docs/Tools.md)
 
+## Testing
+
+Playwright is being used to End 2 End test. You need a working Magento environment with the [Magewire Examples](https://magewire-magento.test/magewire/examples) installed. If you have that, you can run tests like this:
+
+```bash
+npm ci
+npx playwright install --with-deps
+
+# Change the URL to your Magento environment
+BASE_URL=http://localhost:8080/ npx playwright test
+```
+
 ## Sponsors
 Based on proven results, using Magewire consistently reduces work hours, offering significant benefits to agencies,
 their developers and merchants. I extend my heartfelt appreciation to my current sponsors for their support creating

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,91 @@
+{
+  "name": "magewire",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "magewire",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.39.0",
+        "@types/node": "^20.8.10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "magewire",
+  "version": "1.0.0",
+  "description": "[![Latest Stable Version](http://poser.pugx.org/magewirephp/magewire/v)](https://packagist.org/packages/magewirephp/magewire) [![Total Downloads](http://poser.pugx.org/magewirephp/magewire/downloads)](https://packagist.org/packages/magewirephp/magewire) ![style CI](https://github.styleci.io/repos/414967404/shield?style=flat&branch=main) [![License](http://poser.pugx.org/magewirephp/magewire/license)](https://packagist.org/packages/magewirephp/magewire) [![sponsors](https://img.shields.io/badge/Sponsors-2-1abc9c)](https://github.com/sponsors/wpoortman)",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.39.0",
+    "@types/node": "^20.8.10"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,79 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.BASE_URL ? process.env.BASE_URL : 'https://magewire-magento.test',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});
+

--- a/tests/examples.spec.js
+++ b/tests/examples.spec.js
@@ -1,0 +1,94 @@
+const { test, expect } = require('@playwright/test');
+
+test.beforeEach(async ({ page }, testInfo) => {
+    await page.goto('/magewire/examples');
+});
+
+test('Test that the todo behaves as expected', async ({ page }) => {
+    await page.getByPlaceholder('Task Description...').fill('First task');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await page.getByPlaceholder('Task Description...').fill('Second task');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByText('First task')).toBeVisible();
+    await expect(page.getByText('Second task')).toBeVisible();
+});
+
+test('Testing the shuffle function', async ({ page }) => {
+    async function getOrder() {
+        return page.evaluate(() => {
+            return Array.from(document.querySelectorAll('[wire\\:key]')).map(el => el.getAttribute('wire:key'));
+        });
+    }
+
+    // Capture original order
+    const originalOrder = await getOrder();
+
+    // Perform the action that triggers shuffling
+    await page.getByRole('button', { name: 'Shuffle' }).click();
+
+    // Unsure to watch for al element so wait for 1 second.
+    await page.waitForTimeout(1000);
+
+    // Capture new order
+    await expect((await getOrder()).toString()).not.toEqual(originalOrder.toString());
+});
+
+test('Test that we can click the next and previous button', async ({ page }) => {
+    let paginationCount = page.locator('#pagination td.font-bold');
+
+    await expect(paginationCount.getByText('0', { exact: true })).toBeVisible();
+
+    await page.getByRole('button', { name: '»' }).click();
+    await expect(page.getByRole('cell', { name: '10' }).first()).toBeVisible();
+
+    await page.getByRole('button', { name: '»' }).click();
+    await expect(page.getByRole('cell', { name: '20' }).first()).toBeVisible();
+
+    await page.getByRole('button', { name: '«' }).click();
+    await expect(page.getByRole('cell', { name: '10' }).first()).toBeVisible();
+});
+
+test('Test that input will not validate with invalid data', async ({ page }) => {
+    // Skipping the lastname + email on purpose
+    await page.getByPlaceholder('Firstname').fill('John');
+
+    await page.getByRole('button', { name: 'Validate' }).click();
+    await expect(page.getByText('Your lastname is required')).toBeVisible();
+    await expect(page.getByText('Your email is required')).toBeVisible();
+});
+
+test('Test that email addresses need to be in the correct format', async ({ page }) => {
+    await page.getByPlaceholder('Firstname').fill('John');
+    await page.getByPlaceholder('Lastname').fill('Doe');
+    await page.getByPlaceholder('Email', { exact: true }).fill('invalid value');
+
+    await page.getByRole('button', { name: 'Validate' }).click();
+    await expect(page.getByText('Your email is not valid email')).toBeVisible();
+});
+
+test('Test that input verification works', async ({ page }) => {
+    await page.getByPlaceholder('Firstname').fill('John');
+    await page.getByPlaceholder('Lastname').fill('Doe');
+    await page.getByPlaceholder('Email', { exact: true }).fill('Email@email.email');
+
+    await page.getByRole('button', { name: 'Validate' }).click();
+    await expect(page.getByText('Validation success!')).toBeVisible();
+});
+
+test('Test that the add/subtract buttons work as expected', async ({ page }) => {
+    let number = page.locator('#reacticon');
+    let button = page.getByRole('button', { name: '+1' });
+    let button2 = page.getByRole('button', { name: '−1' });
+
+    // Go from 1 (start position), add to, so we get 3.
+    await button.click();
+    await button.click();
+    await expect(number.getByText('3')).toBeVisible();
+
+    // Subtract 1, should be 2
+    await button2.click();
+    await expect(number.getByText('2')).toBeVisible();
+});
+


### PR DESCRIPTION
Hello,

To improve the stability of this open source project, I've create this pull request together @https://github.com/michielgerritsen to add End 2 End tests. The added Github Action does the following:

- It sets up a Magento environment.
- It adds the Hyvä theme.
- It installs Magewire and https://github.com/magewirephp/magewire-examples.
- It runs Playwright against this environment.

During testing, the Magewire Examples page is used to check that everything is working as expected. These tests are included:
- Adding todos. Editing seems broke so we've skipped that.
- Test the shuffle function. In rare cases this might fail as it could that the new order is the same as the old order.
- Clicking the previous and next button for the pagination.
- Validating data, with both invalid and valid data.
- Adding and subtracting numbers.

To install Hyvä in the pipeline we've added a private key to Hyvä's Gitlab so we could install it. To merge this, the `SSH_PRIVATE_KEY` secret must be added, which should be in a `id_ed25519` format.

There is probably more to test, but the main goal was to get some test up & running to be able to expand from that.