### PR TITLE
Fix compilation in upload component branch

### DIFF
--- a/src/Exception/NoSuchUploadAdapterInterface.php
+++ b/src/Exception/NoSuchUploadAdapterInterface.php
@@ -9,10 +9,11 @@
 namespace Magewirephp\Magewire\Exception;
 
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
 
 class NoSuchUploadAdapterInterface extends MagewireException
 {
-    public function __construct(string $name, Exception $cause = null, $code = 0)
+    public function __construct(Phrase $phrase, \Exception $cause = null, $code = 0)
     {
         parent::__construct(
             __('No such upload adapter.'),

--- a/src/Model/Storage/Driver/S3.php
+++ b/src/Model/Storage/Driver/S3.php
@@ -16,4 +16,9 @@ class S3 extends StorageDriver
     {
         // TODO: Implement store() method.
     }
+
+    public function publish(array $paths, string $directory = null, string $filename = null): array
+    {
+        // TODO: Implement publish() method.
+    }
 }


### PR DESCRIPTION
First error:
```
Compilation was started.
Repositories code generation... 1/9 [===>------------------------]  11% 1 sec 135.0 MiB
Fatal error: Class Magewirephp\Magewire\Model\Storage\Driver\S3 contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Magewirephp\Magewire\Model\Storage\StorageDriver::publish) in /Users/tjitse/sites/maximakitchen/vendor/magewirephp/magewire/src/Model/Storage/Driver/S3.php on line 13
```

Second error:
```
Compilation was started.
Area configuration aggregation... 5/9 [===============>------------]  55% 28 secs 418.0 MiB
In ClassReader.php line 57:

  Impossible to process constructor argument Parameter #1 [ <optional> ?Magewirephp\Magewire\Exception\Exception $cause = NULL ] of Magewirephp\Magewire\Exception\NoSuchUploadAdapterInterface class


In GetParameterClassTrait.php line 34:

  Class "Magewirephp\Magewire\Exception\Exception" does not exist
```