### PR TITLE
Avoid TypeError in bussy queue

### DIFF
--- a/src/view/frontend/templates/page/js/magewire/plugin/loader.phtml
+++ b/src/view/frontend/templates/page/js/magewire/plugin/loader.phtml
@@ -102,7 +102,7 @@ $magewireScripts = $block->getViewModel();
                 }
 
                 let first = ! queue.some(({ parent }) => parent);
-                let me = queue.findIndex(item => item.component.id === component.id);
+                let me = queue.findIndex(item => item && item.component && item.component.id === component.id);
 
                 if (first) {
                     queue.push({


### PR DESCRIPTION
In setting where there is a lot of child blocks notices that sometimes there were TypeError thrown processing Queue. In my case debugger were showing that queue length is 4 where only three elements were populated (as element indexed with zero was removed due to being processed already).

I can see similar TypeError defence as suggested here is used elsewhere in the same file.