### PR TITLE
V1: Add layout to fingerprint to enable layout-level Magewire components

### DIFF
--- a/src/Model/Component/Resolver/Layout.php
+++ b/src/Model/Component/Resolver/Layout.php
@@ -85,6 +85,9 @@ class Layout implements ResolverInterface
     public function reconstruct(RequestInterface $request): Component
     {
         $page = $this->resultPageFactory->create();
+        if ($request->getFingerprint('layout')) {
+            $page->getConfig()->setPageLayout(strtolower($request->getFingerprint('layout')));
+        }
         $page->addHandle(strtolower($request->getFingerprint('handle')))->initLayout();
 
         /**

--- a/src/Model/ComponentManager.php
+++ b/src/Model/ComponentManager.php
@@ -12,6 +12,7 @@ use Exception;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Locale\Resolver;
 use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Page\Config;
 use Magewirephp\Magewire\Exception\AcceptableException;
 use Magewirephp\Magewire\Component;
 use Magewirephp\Magewire\Exception\ComponentHydrationException;
@@ -21,6 +22,7 @@ class ComponentManager
 {
     protected Resolver $localeResolver;
     protected HttpFactory $httpFactory;
+    protected Config $pageConfig;
     protected array $updateActionsPool;
     protected array $hydrationPool;
 
@@ -28,12 +30,14 @@ class ComponentManager
         HydratorContext $hydratorContext,
         Resolver $localeResolver,
         HttpFactory $httpFactory,
+        Config $pageConfig,
         array $updateActionsPool = [],
         array $hydrationPool = []
     ) {
         $this->localeResolver = $localeResolver;
         $this->updateActionsPool = $updateActionsPool;
         $this->httpFactory = $httpFactory;
+        $this->pageConfig = $pageConfig;
 
         // Core Hydrate & Dehydrate lifecycle sort order.
         $this->hydrationPool = $this->sortHydrators($hydrationPool, [
@@ -153,7 +157,8 @@ class ComponentManager
 
                 // Custom relative to Livewire's core.
                 'handle' => $handle ?? $request->getFullActionName(),
-                'type' => $component::COMPONENT_TYPE
+                'type' => $component::COMPONENT_TYPE,
+                'layout' => $this->pageConfig->getPageLayout()
             ],
 
             'serverMemo' => [


### PR DESCRIPTION
This makes it possible to define a Magewire component in a page_layout file, configure a category (or CMS page, etc.) to use this layout file, and have the component function as expected.

This functionality can be tested using the module below:
[reproduction.zip](https://github.com/magewirephp/magewire/files/14636965/reproduction.zip)

In the current Magewire codebase; if you configure a category to use the test layout that this module defines and load that category the initial render will succeed, but any changes will result in a 404 error because the Magewire Module cannot be found in the default catalog_category_view template.

With this change the module will function.