### PR TITLE
fix: catch any serialisation related error and return/response as json

### DIFF
--- a/src/Model/Request/MagewireValidator.php
+++ b/src/Model/Request/MagewireValidator.php
@@ -35,7 +35,12 @@ class MagewireValidator implements ValidatorInterface
             return;
         }
 
-        $input = $this->serializer->unserialize(file_get_contents('php://input'));
+        try {
+            $input = $this->serializer->unserialize(file_get_contents('php://input'));
+        }  catch (\Exception $exception) {
+            $this->throwException($exception->getMessage());
+        }
+
         $handle = $input['fingerprint']['handle'] ?? null;
 
         if (! $handle || preg_match('/^[a-zA-Z0-9][a-zA-Z\d\-_\.]*$/', $handle) !== 1) {


### PR DESCRIPTION
When hitting magewire without parameter , serialisation  failed with php error. Addin a catch to fall back to expected error reporting 