### PR TITLE
fix: modal closes when clicking on overlay

### DIFF
--- a/src/view/frontend/templates/html/loader/overlay.phtml
+++ b/src/view/frontend/templates/html/loader/overlay.phtml
@@ -20,6 +20,7 @@ $magewireScripts = $block->getViewModel();
             top-0 left-0 right-0 bottom-0
             w-full h-screen
             overflow-hidden
+            pointer-events-none
             bg-white bg-opacity-90"
      <?php /* AlpineJS v2.x */ ?>
      x-spread="overlay()"


### PR DESCRIPTION
Currently, when a modal is active and a loader overlay is visible, the modal closes when clicking on the overlay.

This merge requests fixes this issue.

Steps to reproduce on https://checkout-demo.hyva.io:
- Log in as a customer and make sure to have at least one address.
- Add a product to the cart and go to the checkout
- Click 'New Address'
- Open the the Country dropdown by clicking on 'United States'
- Click on another country and **immedialy after** click on the 'City' input field.
- Now the modal closes, which is inconvenient