### PR TITLE
Fix overlay clickthroughs 

### DIFF
--- a/src/view/frontend/templates/html/loader/overlay.phtml
+++ b/src/view/frontend/templates/html/loader/overlay.phtml
@@ -20,7 +20,6 @@ $magewireScripts = $block->getViewModel();
             top-0 left-0 right-0 bottom-0
             w-full h-screen
             overflow-hidden
-            pointer-events-none
             bg-white bg-opacity-90"
      <?php /* AlpineJS v2.x */ ?>
      x-spread="overlay()"


### PR DESCRIPTION
Remove the pointer-events-none class from the overlay. This class disables pointer events, allowing interaction with elements behind the overlay, which defeats its purpose, especially for an overlay containing a spinner.

I encountered this issue while working on the Hyvä checkout with Stripe. If the user double-clicked 'Proceed to review & payments,' the Google Wallet payment option would sometimes appear twice, as each click caused digital wallet methods (like Google and Apple Pay) to initialize multiple times.