### PR TITLE
Update LoaderOverlay for dynamic property issue

### DIFF
--- a/src/Model/Magento/Config/Source/LoaderOverlay.php
+++ b/src/Model/Magento/Config/Source/LoaderOverlay.php
@@ -11,6 +11,12 @@ namespace Magewirephp\Magewire\Model\Magento\Config\Source;
 class LoaderOverlay implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
+    *@var array<string, string>
+    **/
+    private array $options;
+
+    
+    /**
      * @param array<string, string> $options
      */
     public function __construct(


### PR DESCRIPTION
fix for admin panel when in developer mode for the following error

```1 exception(s):
Exception #0 (Exception): Deprecated Functionality: Creation of dynamic property Magewirephp\Magewire\Model\Magento\Config\Source\LoaderOverlay::$options is deprecated in /app/project/vendor/magewirephp/magewire/src/Model/Magento/Config/Source/LoaderOverlay.php on line 19