### PR TITLE
The initialize script cannot be loaded async in hyva-themes

### DIFF
--- a/src/view/frontend/templates/page/js/magewire-initialize.phtml
+++ b/src/view/frontend/templates/page/js/magewire-initialize.phtml
@@ -34,8 +34,6 @@ $magewireScripts = $block->getViewModel();
         window.Livewire = window.magewire
         window.Magewire = window.magewire
         window.livewire_app_url = '<?= $escaper->escapeUrl($magewireScripts->getApplicationUrl()) ?>'
-        <?php /* Still Hyvä dependent, will change in the future to spread compatibility. */ ?>
-        window.livewire_token = window.hyva.getFormKey()
 
         <?php /* Make sure Magewire loads first. */ ?>
         if (window.Alpine) {
@@ -53,6 +51,9 @@ $magewireScripts = $block->getViewModel();
             const startMagewireOnce = () => {
                 document.removeEventListener('DOMContentLoaded', startMagewireOnce)
                 window.removeEventListener('alpine:init', startMagewireOnce)
+                <?php /* Still Hyvä dependent, will change in the future to spread compatibility. */ ?>
+                window.livewire_token = window.hyva.getFormKey()
+
                 window.magewire.start()
             }
 


### PR DESCRIPTION
In the current Hyva theme the order of how scripts are loaded is currently important.

When this changes there is a change that window.hyva.getFormkey() isn't initialized yet.

This would break the script and that would mean that magewire isn't loaded correctly.
By moving this to the page-load or alpine:init it will be loaded after all javascript on the page is loaded.

The token is needed to make posting to the magewire endpoint possible.

Thanks