### PR TITLE
Compatibility with Magento 2.4.8 and Mage-OS 1.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "magento/framework": "*",
     "rakit/validation": "^1.0",
     "php": ">=8.1",
-    "symfony/http-foundation": "^5.4 || ^6.0"
+    "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
   },
   "support": {
     "issues": "https://github.com/magewirephp/magewire/discussions"


### PR DESCRIPTION
This resolves the issue preventing Hyvä Checkout to be installed on Magento or Adobe Commerce 2.4.8. The same is true for Mage-OS 1.1.1. Well, when this change is released the issue will be resolved :)