### PR TITLE
PHP 8.4 Support

### DIFF
--- a/lib/Magento/View/Layout/GeneratorPool.php
+++ b/lib/Magento/View/Layout/GeneratorPool.php
@@ -23,8 +23,8 @@ class GeneratorPool extends \Magento\Framework\View\Layout\GeneratorPool
         ConditionFactory $conditionFactory,
         LoggerInterface $logger,
         MagewireLayoutScheduledStructureHelper $magewireLayoutScheduledStructureHelper,
-        array $generators = null,
-        ?State $state = null
+        array|null $generators = null,
+        State|null $state = null
     ) {
         parent::__construct($helper, $conditionFactory, $logger, $generators, $state);
 

--- a/lib/Magewire/Features/SupportMagewireCompiling/HandlesMagewireCompiling.php
+++ b/lib/Magewire/Features/SupportMagewireCompiling/HandlesMagewireCompiling.php
@@ -17,7 +17,7 @@ trait HandlesMagewireCompiling
     private Compiler|null $compiler = null;
     private bool $compile = true;
 
-    public function compiler(Compiler $compiler = null): Compiler|null
+    public function compiler(Compiler|null $compiler = null): Compiler|null
     {
         if ($compiler) {
             $this->compiler = $compiler;

--- a/lib/Magewire/Features/SupportMagewireCompiling/View/Compiler.php
+++ b/lib/Magewire/Features/SupportMagewireCompiling/View/Compiler.php
@@ -105,7 +105,7 @@ abstract class Compiler
         return true;
     }
 
-    public function canCompile(bool $choice = null): bool|static
+    public function canCompile(bool|null $choice = null): bool|static
     {
         if ($choice) {
             $this->compile = $choice;

--- a/lib/Magewire/Features/SupportMagewireViewInstructions/ViewInstructions.php
+++ b/lib/Magewire/Features/SupportMagewireViewInstructions/ViewInstructions.php
@@ -76,7 +76,7 @@ class ViewInstructions
     /**
      * Returns the amount of batched evaluation results.
      */
-    public function count(array $items = null): int
+    public function count(array|null $items = null): int
     {
         return count($items ?? $this->instructions);
     }
@@ -84,7 +84,7 @@ class ViewInstructions
     /**
      * Clear the current batch from existing evaluation results.
      */
-    public function clear(callable $filter = null): self
+    public function clear(callable|null $filter = null): self
     {
         $this->instructions = $filter ? $this->filter($filter) : [];
 
@@ -113,7 +113,7 @@ class ViewInstructions
      * Check if the current batch owns a specific evaluation result
      * and optionally executes the callback if so.
      */
-    public function owns(callable $filter, ?callable $callback = null): bool
+    public function owns(callable $filter, callable|null $callback = null): bool
     {
         $result = count($this->filter($filter)) > 0;
 
@@ -128,7 +128,7 @@ class ViewInstructions
      * Check if the current batch misses a specific evaluation result
      * and optionally executes the callback if so.
      */
-    public function misses(callable $filter, ?callable $callback = null): bool
+    public function misses(callable $filter, callable|null $callback = null): bool
     {
         $result = count($this->filter($filter)) === 0;
 
@@ -142,7 +142,7 @@ class ViewInstructions
     /**
      * Walk over each evaluation result object.
      */
-    public function walk(callable $callback, callable $filter = null): self
+    public function walk(callable $callback, callable|null $filter = null): self
     {
         // Emulates the functionality of array_walk while incorporating filtering capabilities.
         foreach (array_filter($this->instructions, $filter ?? fn () => true) as $item) {
@@ -155,7 +155,7 @@ class ViewInstructions
     /**
      * Returns if the batch doesn't contain any results.
      */
-    public function isEmpty(callable $filter = null): bool
+    public function isEmpty(callable|null $filter = null): bool
     {
         return $this->count($filter ? $this->filter($filter) : $this->instructions) === 0;
     }
@@ -163,7 +163,7 @@ class ViewInstructions
     /**
      * Returns if the batch contains more then one result.
      */
-    public function isPlural(callable $filter = null): bool
+    public function isPlural(callable|null $filter = null): bool
     {
         return $this->count($filter ? $this->filter($filter) : $this->instructions) > 1;
     }
@@ -171,7 +171,7 @@ class ViewInstructions
     /**
      * Returns if the batch contains only one result.
      */
-    public function isSingular(callable $filter = null): bool
+    public function isSingular(callable|null $filter = null): bool
     {
         return $this->count($filter ? $this->filter($filter) : $this->instructions) === 1;
     }

--- a/lib/Magewire/Features/SupportMagewireViewModel/MagewireViewModel.php
+++ b/lib/Magewire/Features/SupportMagewireViewModel/MagewireViewModel.php
@@ -21,7 +21,7 @@ class MagewireViewModel implements ArgumentInterface
         //
     }
 
-    public function utils(string $name = null, array $arguments = []): ViewUtils
+    public function utils(string|null $name = null, array $arguments = []): ViewUtils
     {
         return $name ? $this->utils->$name($arguments) : $this->utils;
     }

--- a/lib/MagewireBc/Model/RequestInterface.php
+++ b/lib/MagewireBc/Model/RequestInterface.php
@@ -73,7 +73,7 @@ interface RequestInterface
      * @param bool $force
      * @return \Magewirephp\Magewire\Model\RequestInterface|bool
      */
-    public function isSubsequent(bool $flag = null, bool $force = false);
+    public function isSubsequent(bool|null $flag = null, bool $force = false);
 
     /**
      * Check if on a component initialization request.
@@ -88,7 +88,7 @@ interface RequestInterface
      * @param bool|null $flag
      * @return \Magewirephp\Magewire\Model\RequestInterface|bool
      */
-    public function isRefreshing(bool $flag = null);
+    public function isRefreshing(bool|null $flag = null);
 
     /**
      * @return array

--- a/portman/Livewire/LivewireManager.php
+++ b/portman/Livewire/LivewireManager.php
@@ -36,7 +36,7 @@ class LivewireManager extends \Livewire\LivewireManager
     /**
      * @throws NotFoundException
      */
-    public function mount($name, $params = [], $key = null, AbstractBlock $block = null, Component $component = null): void
+    public function mount($name, $params = [], $key = null, AbstractBlock|null $block = null, Component|null $component = null): void
     {
         /** @var HandleComponentsFacade $handleComponentsMechanismFacade */
         $handleComponentsMechanismFacade = $this->magewireServiceProvider->getHandleComponentsMechanismFacade();
@@ -50,7 +50,7 @@ class LivewireManager extends \Livewire\LivewireManager
      * @throws RuntimeException
      * @throws NotFoundException
      */
-    public function update($snapshot, $diff, $calls, AbstractBlock $block = null): void
+    public function update($snapshot, $diff, $calls, AbstractBlock|null $block = null): void
     {
         /** @var HandleComponentsFacade $handleComponentsMechanismFacade */
         $handleComponentsMechanismFacade = $this->magewireServiceProvider->getHandleComponentsMechanismFacade();

--- a/portman/Livewire/Mechanisms/HandleComponents/HandleComponents.php
+++ b/portman/Livewire/Mechanisms/HandleComponents/HandleComponents.php
@@ -51,7 +51,7 @@ class HandleComponents extends \Livewire\Mechanisms\HandleComponents\HandleCompo
         });
     }
 
-    public function mount($name, $params = [], $key = null, AbstractBlock $block = null, Component $component = null)
+    public function mount($name, $params = [], $key = null, AbstractBlock|null $block = null, Component|null $component = null)
     {
         $parent = last(self::$componentStack);
 
@@ -130,7 +130,7 @@ class HandleComponents extends \Livewire\Mechanisms\HandleComponents\HandleCompo
      * @throws MethodNotFoundException
      * @throws RuntimeException
      */
-    public function update($snapshot, $updates, $calls, AbstractBlock $block = null)
+    public function update($snapshot, $updates, $calls, AbstractBlock|null $block = null)
     {
         if ($block === null) {
             throw new InvalidArgumentException('Argument $block can not be of type null.');
@@ -195,7 +195,7 @@ class HandleComponents extends \Livewire\Mechanisms\HandleComponents\HandleCompo
         };
     }
 
-    protected function render($component, $default = null, string $html = null)
+    protected function render($component, $default = null, string|null $html = null)
     {
         $replace = store($component)->get('skipRender', false);
 
@@ -306,7 +306,7 @@ class HandleComponents extends \Livewire\Mechanisms\HandleComponents\HandleCompo
      * @throws RuntimeException
      * @throws Exception
      */
-    public function fromSnapshot($snapshot, AbstractBlock $block = null)
+    public function fromSnapshot($snapshot, AbstractBlock|null $block = null)
     {
         if (! $block instanceof AbstractBlock) {
             throw new Exception(

--- a/src/Component/Form.php
+++ b/src/Component/Form.php
@@ -52,7 +52,7 @@ abstract class Form extends Component
     public function validate(
         array $rules = [],
         array $messages = [],
-        array $data = null,
+        array|null $data = null,
         array $aliases = [],
         bool $mergeWithClassProperties = true
     ): bool {
@@ -97,7 +97,7 @@ abstract class Form extends Component
     /**
      * @throws AcceptableException
      */
-    public function validateOnly(array $rules = [], array $messages = [], array $data = null): bool
+    public function validateOnly(array $rules = [], array $messages = [], array|null $data = null): bool
     {
         return $this->validate($rules, $messages, $data, [], false);
     }

--- a/src/Model/Magento/System/ConfigMagewire.php
+++ b/src/Model/Magento/System/ConfigMagewire.php
@@ -29,7 +29,7 @@ class ConfigMagewire
      */
     public function getGroupValue(
         string $path,
-        string $group = null,
+        string|null $group = null,
         string $scopeType = ScopeInterface::SCOPE_STORE,
         $scopeCode = null
     ): mixed {
@@ -41,7 +41,7 @@ class ConfigMagewire
      */
     public function isGroupFlag(
         string $path,
-        string $group = null,
+        string|null $group = null,
         string $scopeType = ScopeInterface::SCOPE_STORE,
         $scopeCode = null
     ): bool {
@@ -95,7 +95,7 @@ class ConfigMagewire
     /**
      * Returns a formatted path based on the provided path and optional group.
      */
-    private function createPath(string $path, string $group = null): string
+    private function createPath(string $path, string|null $group = null): string
     {
         return $group
             ? sprintf('magewire/%s/%s', $group, trim($path))


### PR DESCRIPTION
Currently, if you run `bin/magento setup:di:compile` in PHP `8.4`, you run into an error.

This Pull request declares nullable parameters explicitly to resolve PHP deprecation warnings.