### PR TITLE
Update overlay.phtml to disable pointer events 

### DIFF
--- a/src/view/frontend/templates/html/loader/overlay.phtml
+++ b/src/view/frontend/templates/html/loader/overlay.phtml
@@ -18,6 +18,7 @@ use Magento\Framework\View\Element\Template;
             top-0 left-0 right-0 bottom-0
             w-full h-screen
             overflow-hidden
+            pointer-events-none
             bg-white bg-opacity-90"
      <?php /* AlpineJS v2.x */ ?>
      x-spread="overlay"


### PR DESCRIPTION
Disable pointer events on the loader overlay to stop click events from bubbling to underlying components (e.g. modals), which caused

unexpected modal closures during form interaction.