### PR TITLE
ci: auto-fix PRs with Mago in place

### DIFF
--- a/.github/workflows/mago-pr-fix.yml
+++ b/.github/workflows/mago-pr-fix.yml
@@ -36,7 +36,7 @@ jobs:
         run: mago lint --fix --format-after-fix || true
 
       - name: Mago format
-        run: mago format --fix
+        run: mago format
 
       - name: Restore mago.toml
         run: git checkout -- mago.toml

--- a/.github/workflows/mago-pr-fix.yml
+++ b/.github/workflows/mago-pr-fix.yml
@@ -1,0 +1,53 @@
+name: 'Mago (PR auto-fix)'
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+
+  mago-fix:
+    runs-on: ubuntu-latest
+    # Only same-repo PRs are pushable; skip forks (mago.yml still checks them).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MY_TOKEN }}
+          ref: ${{ github.head_ref }}
+
+      - name: Install Mago
+        env:
+          MAGO_VERSION: '1.27.1'
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://carthage.software/mago.sh | bash -s -- --no-verify --version="$MAGO_VERSION"
+          mago --version
+
+      - name: Strip external includes from mago.toml
+        run: sed -i '/^includes\s*=/d' mago.toml
+
+      # Safe fixes only; '|| true' so unfixable issues don't abort before format.
+      - name: Mago lint fix (safe)
+        run: mago lint --fix --format-after-fix || true
+
+      - name: Mago format
+        run: mago format --fix
+
+      - name: Restore mago.toml
+        run: git checkout -- mago.toml
+
+      - name: Commit & push fixes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if ! git diff --quiet; then
+            git commit -am 'style: apply Mago safe fixes and formatting'
+            git push
+          else
+            echo 'No Mago changes needed.'
+          fi

--- a/lib/Magewire/Features/SupportMagewireCompiling/View/Compiler/MagentoTemplateCompiler.php
+++ b/lib/Magewire/Features/SupportMagewireCompiling/View/Compiler/MagentoTemplateCompiler.php
@@ -39,7 +39,7 @@ class MagentoTemplateCompiler extends Compiler
                 ->template()
                 ->middleware()
                 ->group($group)
-                ->pipe(fn (string $throughput, callable $next): mixed => $next($middleware->compile($throughput)));
+                ->pipe(static fn (string $throughput, callable $next): mixed => $next($middleware->compile($throughput)));
         }
 
         return $pipeline;

--- a/lib/Magewire/Mechanisms/ResolveComponents/Management/ComponentResolverManager.php
+++ b/lib/Magewire/Mechanisms/ResolveComponents/Management/ComponentResolverManager.php
@@ -90,10 +90,12 @@ class ComponentResolverManager
             $resolver = null;
 
             foreach ($this->resolvers as $key => $componentResolver) {
-                if ($componentResolver->complies($block, $block->getData('magewire'))) {
-                    $resolver = $key;
-                    break;
+                if (! $componentResolver->complies($block, $block->getData('magewire'))) {
+                    continue;
                 }
+
+                $resolver = $key;
+                break;
             }
 
             $resolver = $this->createResolverByAccessor($resolver ?? 'unknown');

--- a/src/Model/View/Fragment/Component.php
+++ b/src/Model/View/Fragment/Component.php
@@ -78,9 +78,11 @@ abstract class Component extends Html
     public function distribute(array $data): static
     {
         foreach ($data as $name => $value) {
-            if (is_array($value)) {
-                $this->properties()->target($name)->fill($value);
+            if (! is_array($value)) {
+                continue;
             }
+
+            $this->properties()->target($name)->fill($value);
         }
 
         return $this;

--- a/src/view/frontend/templates/js/magewire/object-proxy.phtml
+++ b/src/view/frontend/templates/js/magewire/object-proxy.phtml
@@ -41,41 +41,41 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
     (() => {
         document.addEventListener('magewire:init', event => {
             <?php /* Overwrite __magewireIsProxy and __magewireInfo on the real instance once Magewire
-                   * has initialized, so callers can distinguish the Proxy from the live API. */ ?>
+             * has initialized, so callers can distinguish the Proxy from the live API. */ ?>
             Magewire.__magewireIsProxy = function () {
                 return false;
             };
         });
 
         <?php /* If the real Magewire has already loaded (e.g. scripts were reordered),
-               * skip the Proxy entirely — there is nothing to stand in for. */ ?>
+         * skip the Proxy entirely — there is nothing to stand in for. */ ?>
         if (window.Magewire) {
             return;
         }
 
         <?php /* Queue that collects method calls made on the Proxy before the real Magewire
-               * loads. Each entry stores the method name (prop) and its arguments. */ ?>
+         * loads. Each entry stores the method name (prop) and its arguments. */ ?>
         const magewireBcProxyQueue = [
             // Empty by default.
         ];
         <?php /* Map of known backwards-compatibility functions. When the queue is replayed
-               * after init, only calls matching a key here are executed — unknown calls
-               * are silently discarded to avoid errors from removed or renamed APIs. */ ?>
+         * after init, only calls matching a key here are executed — unknown calls
+         * are silently discarded to avoid errors from removed or renamed APIs. */ ?>
         const magewireBcFunctions = {
             onError: magewireBcOnError
         };
 
         <?php /* The Proxy target contains stub properties that are safe to access before init.
-               * The Proxy handler's get() trap intercepts any other property access and returns
-               * a function that queues the call for later replay. */ ?>
+         * The Proxy handler's get() trap intercepts any other property access and returns
+         * a function that queues the call for later replay. */ ?>
         window.Magewire = new Proxy({
             __magewireIsProxy: function() {
                 return true;
             },
 
             <?php /* Provide a no-op components.onErrorCallback so legacy code that does
-                   * const orig = Magewire.components.onErrorCallback` doesn't crash when
-                   * it calls `orig(status, response)` inside the onError handler. */ ?>
+             * const orig = Magewire.components.onErrorCallback` doesn't crash when
+             * it calls `orig(status, response)` inside the onError handler. */ ?>
             components: {
                 onErrorCallback: () => {}
             }
@@ -92,12 +92,12 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
         });
 
         <?php /* V1 -> V3 onError bridge.
-               * Translates the legacy Magewire.onError(callback) signature into a Livewire v3
-               * request hook. The old callback received (status, response); V2 provides
-               * {status, content, preventDefault}. A synthetic Response-like object is built
-               * from the plain-text content so existing callbacks that call response.text()
-               * or response.json() continue to work unchanged. Returning false from the
-               * legacy callback calls preventDefault(), matching V1 suppression behavior. */ ?>
+         * Translates the legacy Magewire.onError(callback) signature into a Livewire v3
+         * request hook. The old callback received (status, response); V2 provides
+         * {status, content, preventDefault}. A synthetic Response-like object is built
+         * from the plain-text content so existing callbacks that call response.text()
+         * or response.json() continue to work unchanged. Returning false from the
+         * legacy callback calls preventDefault(), matching V1 suppression behavior. */ ?>
         function magewireBcOnError(callback) {
             Magewire.hook('request', ({ fail }) => {
                 fail(({ status, content, preventDefault }) => {
@@ -130,8 +130,8 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
         }
 
         <?php /* Once the real Magewire is available, drain the queue: replay each captured
-               * call through magewireBcFunctions so the registrations take effect on the
-               * live instance. The queue is consumed in insertion order (FIFO). */ ?>
+         * call through magewireBcFunctions so the registrations take effect on the
+         * live instance. The queue is consumed in insertion order (FIFO). */ ?>
         document.addEventListener('magewire:init', event => {
             for (const { prop, args } of magewireBcProxyQueue) {
                 if (prop in magewireBcFunctions && typeof magewireBcFunctions[prop] === 'function') {


### PR DESCRIPTION
On same-repo PRs to `main`, run Mago safe lint fixes + formatting and commit the result back onto the PR branch — reviewers see already-linted code. No second PR.

- Pushes the fix commit with `secrets.MY_TOKEN` so the existing `mago.yml` check retriggers and goes green.
- Idempotent → no commit loop.
- Fork PRs skipped (read-only token); `mago.yml` still gates them.

Follow-ups (settings, not code):
- Confirm `MY_TOKEN` PAT has `repo` + `workflow` scope.
- Keep **Mago** required check scoped to `main` (just adjusted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)