### PR TITLE
feat: add script DOM placements

### DIFF
--- a/.agents/skills/magewire-architecture/SKILL.md
+++ b/.agents/skills/magewire-architecture/SKILL.md
@@ -1,0 +1,634 @@
+---
+name: magewire-architecture
+description: "Internals and extension guide for the Magewire framework: directory layout (src/lib/dist/portman), Mechanisms vs Features, area-scoped DI (frontend/adminhtml), snapshot/state flow, layout containers, JS extension points, and Facades. Use when extending Magewire, creating custom Features or Mechanisms, debugging the framework itself, or understanding how the codebase is structured."
+license: MIT
+metadata:
+  author: Willem Poortman
+---
+
+# Magewire Architecture
+
+Magewire's codebase is split into two layers: an upstream Livewire core (PHP, ported and maintained via Portman) and a Magento integration layer (controllers, blocks, DI, layout, templates). Understanding this split is essential for knowing where to add or change things.
+
+---
+
+## Repository Layout
+
+```
+vendor/magewirephp/magewire/
+├── src/                        # Magento module structure (hand-written, must live here for Magento)
+│   ├── Component.php           # Base component class (public API)
+│   ├── MagewireServiceProvider.php
+│   ├── Controller/             # Route controllers (magewire/update)
+│   ├── Model/                  # Magento-specific models, view utils, fragment handling
+│   ├── Observer/               # Magento event observers
+│   ├── Plugin/                 # Magento plugin interceptors
+│   ├── ViewModel/              # MagewireViewModel (utilities facade)
+│   ├── Exceptions/
+│   ├── etc/                    # module.xml, di.xml, events.xml, routes.xml
+│   └── view/                   # Layout XML, PHTML templates, JS/CSS assets
+│
+├── lib/                        # Hand-written custom code + downloaded Livewire source
+│   ├── Livewire/               # Downloaded upstream Livewire source (Portman input cache)
+│   ├── Magewire/               # Hand-written Magewire core (mechanisms, features, enums, runtime)
+│   ├── MagewireBc/             # Hand-written backwards compatibility layer
+│   ├── Magento/                # Hand-written Magento framework integrations
+│   └── Symfony/                # Hand-written Symfony adaptations
+│
+├── portman/                    # Portman augmentation files
+│   └── Livewire/               # Augmentations: what to change/extend in upstream Livewire
+│
+├── dist/                       # Portman BUILD OUTPUT — do not edit directly
+│   │                           # (Livewire source + augmentations, namespace-transformed)
+│   ├── ComponentHook.php
+│   ├── Mechanisms/
+│   └── Features/
+│
+├── themes/                     # Theme support sub-modules (e.g. Hyva, Luma)
+├── tests/                      # Playwright + other test types
+└── portman.config.php          # Controls Portman: source paths, output dir, transformations
+```
+
+**Rule of thumb**: `src/` and `lib/` (excluding `lib/Livewire/`) are yours to edit freely. `dist/` is Portman-generated — changes belong in `portman/Livewire/` (augmentations) or `portman.config.php`. `lib/Livewire/` is the downloaded upstream source cache — don't edit it either.
+
+---
+
+## Bootstrap & Runtime
+
+Magewire boots through `MagewireServiceProvider`, which is triggered by Magento's DI during the request lifecycle. It registers three types of services in order:
+
+1. **Containers** — Internal DI-like containers (MagewireManager, etc.)
+2. **Mechanisms** — Non-optional core infrastructure (sorted, loaded in order)
+3. **Features** — Optional lifecycle hooks (sorted, loaded in order)
+
+Boot modes per service item (`ServiceTypeItemBootMode`):
+- `LAZY` (10) — Boot only when needed
+- `PERSISTENT` (20) — Boot during setup phase, persists across request modes
+- `ALWAYS` (30) — Boot on every request (default)
+
+Runtime state progression: `UNINITIALIZED → SETUP → BOOTING → BOOTED` (or `FAILED / STOPPED`). Enum lives at `lib/Magewire/Enums/RuntimeState.php` and exposes ordinal helpers `isMinimally()`, `isMaximally()`, `isAbove()`, `isBelow()` — guards prefer ordinal comparisons over equality.
+
+Request modes (`lib/Magewire/Enums/RequestMode.php`):
+- `PRECEDING` — initial page load (block render path).
+- `SUBSEQUENT` — Magewire XHR update.
+- `UNDEFINED` — pre-boot sentinel; `Runtime::mode()` rejects re-setting it.
+
+### Boot trigger points
+
+`MagewireServiceProvider::boot(RequestMode $mode)` is called from exactly two places:
+
+1. **`Controller/MagewireUpdateRoute::match()`** — fires `boot(SUBSEQUENT)` when the router matches the Magewire update endpoint. Runs once per XHR.
+2. **`Observer/ViewBlockAbstractToHtmlBefore::execute()`** — fires `boot(PRECEDING)` the first time a block carrying `magewire` data renders.
+
+On a SUBSEQUENT request both fire: the router boots first; later, when the matched block renders inside `HandleRequests::handleUpdate`, the observer enters `boot()` a second time but the state guard short-circuits before any side effects.
+
+### Idempotency & guards
+
+- `boot()` short-circuits when state is `≥ BOOTING`. So a second observer-driven entry while the router's boot is still in flight is a no-op.
+- `Runtime::mode()` is **set-once**: the first non-`UNDEFINED` mode wins; subsequent calls are ignored. The XHR's `SUBSEQUENT` is therefore never downgraded to `PRECEDING` by the later observer call.
+- `MagewireServiceProvider` is a **per-request singleton** under Magento DI (`shared="true"`, default). It is NOT persistent across HTTP requests — every request gets a fresh instance with `state = UNINITIALIZED`. `spl_object_id` collisions across PHP-FPM workers are coincidence; use a random per-instance id if you need to disambiguate logs.
+- `reset(RequestMode)` exists for forcing a re-boot within the same instance (sets state back to `UNINITIALIZED`, then calls `boot()`). Not currently called by the framework itself.
+
+> **Footgun — never DI-inject `Runtime` directly.** `MagewireServiceProvider::runtime()` lazy-creates the singleton via `RuntimeFactory` and caches it on `$this->runtime`. The Runtime that `boot()` mutates is **that cached instance only**. If you inject `Runtime` straight into your own constructor, Magento's DI hands you a **different** Runtime that never sees a `boot()` call — it stays `UNINITIALIZED` / `UNDEFINED` for the whole request and silently misleads any state/mode check. Always go through the service provider: inject `MagewireServiceProvider` and call `$magewireServiceProvider->runtime()` to get the live one.
+
+### setup() vs boot()
+
+`MagewireServiceProvider::setup()` runs the persistent slice only (Containers fully boot; Mechanisms/Features boot with `PERSISTENT` mode). `boot()` calls `setup()` if state is still `UNINITIALIZED`, then boots all remaining (`ALWAYS`) Mechanisms and Features. A `LAZY` service item boots only when something explicitly resolves it.
+
+### Lifecycle events fired during boot
+
+- `trigger('magewire:setup', $runtime)` — emitted from `setup()` after Containers boot, before persistent Mechanisms/Features.
+- `trigger('magewire:boot', $runtime)` — emitted from `boot()` once state is `BOOTING`, before remaining Mechanisms/Features boot. The trigger returns a finisher closure called after all service-type boots succeed.
+- Both events are also re-emitted as Magento observer events (`magewire_on_setup`, `magewire_on_boot`) via the `SupportMagentoObserverEvents` feature, so module developers can hook them through `etc/events.xml`.
+
+---
+
+## Mechanisms
+
+Mechanisms are the non-optional core pipeline. They live in `lib/Magewire/Mechanisms/` (hand-written, Magento-specific) and `dist/Mechanisms/` (ported from Livewire), and run in `sort_order` sequence:
+
+| Sort | Mechanism | Role |
+|------|-----------|------|
+| 1000 | `ResolveComponents` | Discovers and instantiates components from layout blocks |
+| 1050 | `PersistentMiddleware` | Carries persistent data between requests |
+| 1100 | `HandleComponents` | Manages snapshot, properties, synthesizers |
+| 1200 | `HandleRequests` | Orchestrates the full update cycle |
+| 1250 | `DataStore` | Global request-scoped data storage |
+| 1400 | `FrontendAssets` | Serves the JS bundle and manifest |
+
+Mechanisms are registered in `src/etc/frontend/di.xml` and `src/etc/adminhtml/di.xml` separately — never in the global `di.xml`. See the note on area-scoped DI below.
+
+To add a custom mechanism, add an entry to the DI config pointing to a class that extends the mechanism base and implements its contract. Mechanisms cannot be skipped — if you only need optional behavior, use a Feature instead.
+
+---
+
+## Features
+
+Features are optional lifecycle extensions. Each Feature is a `ComponentHook` subclass that hooks into the component lifecycle via `provide()`. They live in `lib/Magewire/Features/` (hand-written, Magewire-specific) or `dist/Features/` (ported from Livewire via Portman).
+
+Key built-in features and their sort orders:
+
+| Sort | Feature | Role |
+|------|---------|------|
+| 700 | `SupportMagewireViewModel` | Auto-injects view_model on blocks |
+| 800 | `SupportMagewireExceptionHandling` | Exception management |
+| 900 | `SupportMagewireRateLimiting` | Rate limiting |
+| 1000 | `SupportNestingComponents` | Parent-child relationships |
+| 1200 | `SupportAttributes` | PHP attribute handling |
+| 1300 | `SupportRedirects` | Redirect effects |
+| 1500 | `SupportLocales` | Locale/i18n support |
+| 1600 | `SupportEvents` | Inter-component events |
+| 5000 | `SupportMagentoLayouts` | Magento layout rendering |
+| 5100 | `SupportMagentoFlashMessages` | Magento session flash messages |
+| 5200 | `SupportMagewireLoaders` | Loader state management |
+| 5200 | `SupportMagewireNotifications` | Toast notification system |
+| 99000 | `SupportLifecycleHooks` | Calls lifecycle methods on components |
+| 99100 | `SupportMagewireBackwardsCompatibility` | Legacy API support |
+
+### Naming Conventions
+
+- `SupportMagewire` prefix — Magewire-specific features (e.g. `SupportMagewireLoaders`)
+- `SupportMagento` prefix — Magento compatibility features (e.g. `SupportMagentoLayouts`)
+
+### The Hook System
+
+Features hook into component lifecycle events using `on()` / `trigger()`. A hook callback must return either another callback (which receives the result) or the original value unchanged.
+
+```php
+use function Magewirephp\Magewire\on;
+
+class SupportMyFeature extends \Magewirephp\Magewire\ComponentHook
+{
+    public static function provide(): void
+    {
+        on('magewire:construct', function () {
+            // Return a callback — it fires AFTER the trigger resolves
+            return function (\Magento\Framework\View\Element\AbstractBlock $block) {
+                // Do something with the block
+                return $block; // Must return the value
+            };
+        });
+    }
+}
+```
+
+Hooks are also observable via Magento's native event system through the `SupportMagentoObserverEvents` feature (sort order 99400). It maps 30+ lifecycle hooks to Magento events with the pattern `magewire_on_{eventname}` (special characters replaced with underscores). This means third-party modules can observe Magewire lifecycle events using standard Magento `events.xml` observers without needing to create a Feature.
+
+### Middleware-Style Hooks
+
+Some hooks support a middleware pattern: if your callback returns a callable, that callable runs **after** the operation completes. This is not available on all hooks — only those that support before/after semantics:
+
+- **`update`** — return a callback that runs after the property is updated (used for `updated*` hooks)
+- **`call`** — return a callback that runs after method execution
+- **`render`** — return a callback that runs after rendering completes (used for `rendered` hook)
+
+```php
+on('update', function ($propertyName, $fullPath, $newValue) {
+    // Runs BEFORE the property update
+
+    return function () use ($fullPath) {
+        // Runs AFTER the property update
+    };
+});
+```
+
+Hooks that do **not** support middleware (e.g., `mount`, `hydrate`, `dehydrate`, `exception`) simply run their callback inline — returning a callable from these has no effect.
+
+### Adding a Custom Feature
+
+1. Create a class extending `Magewirephp\Magewire\ComponentHook`:
+
+```php
+namespace Vendor\Module\Magewire\Features;
+
+use Magewirephp\Magewire\ComponentHook;
+use function Magewirephp\Magewire\on;
+
+class SupportMyFeature extends ComponentHook
+{
+    public static function provide(): void
+    {
+        on('mount', function ($params) {
+            // Runs during mount — no middleware support
+        });
+
+        on('hydrate', function ($memo) { });
+
+        on('dehydrate', function ($context) { });
+
+        on('update', function ($propertyName, $fullPath, $newValue) {
+            // Before update
+            return function () {
+                // After update (middleware pattern)
+            };
+        });
+    }
+}
+```
+
+2. Register in `etc/frontend/di.xml` **and** `etc/adminhtml/di.xml` as needed — never in the global `etc/di.xml`. See the note on area-scoped DI below.
+
+```xml
+<type name="Magewirephp\Magewire\Features">
+    <arguments>
+        <argument name="items" xsi:type="array">
+            <item name="my_feature" xsi:type="array">
+                <item name="type" xsi:type="string">Vendor\Module\Magewire\Features\SupportMyFeature</item>
+                <item name="sort_order" xsi:type="number">5050</item>
+            </item>
+        </argument>
+    </arguments>
+</type>
+```
+
+Place feature PHP code in `src/Features/SupportMyFeature/` and any JS in its corresponding `view/` subfolder.
+
+**Feature templates live at:** `view/{area}/templates/magewire-features/{feature-name}/` — the same convention applies to core framework features (in the Magewire module) and to theme compatibility features (in theme modules like Hyvä). Keeping JS, UI, and other feature-related PHTMLs co-located in a single folder per feature makes ownership and overrides easy to reason about.
+
+---
+
+## Area-Scoped DI: Why `frontend/di.xml` and `adminhtml/di.xml`
+
+Features and Mechanisms **must** be registered in area-specific DI files (`etc/frontend/di.xml`, `etc/adminhtml/di.xml`) rather than the global `etc/di.xml`.
+
+**Why:** Magento's DI system merges global config into every area. If a Feature or Mechanism were declared in the global `di.xml`, it would be impossible for another module to register a different set for frontend vs adminhtml — the global declaration would apply everywhere and couldn't be selectively overridden per area.
+
+By keeping registrations area-scoped:
+- A feature active on the frontend can be absent in the admin (or replaced with a different implementation)
+- Third-party compatibility modules (e.g. `MagewireCompatibilityWithHyva`) can add their own features to `frontend/di.xml` without affecting the admin
+- The admin panel (`adminhtml/di.xml`) can carry a different, leaner or admin-tailored set of features and mechanisms
+
+**Rule:** When adding a Feature or Mechanism to your own module, always register it in `etc/frontend/di.xml`, `etc/adminhtml/di.xml`, or both — depending on which areas it should be active in. Never use `etc/di.xml` for this.
+
+---
+
+## Component Resolvers & Arguments
+
+The `ResolveComponents` mechanism is Magewire-specific (not ported from Livewire) and is one of the most powerful parts of the framework. It determines **how** a Magento block becomes a Magewire component — and it's designed to be extensible, so that components can come from layout XML, widgets, API calls, or any custom source.
+
+### How Resolution Works
+
+The `ComponentResolverManager::resolve($block)` walks a priority list, top-down. The first hit wins; later steps don't run.
+
+1. **Explicit override.** `<argument name="magewire:resolver" xsi:type="string">…</argument>` on the block. Highest priority — lets layout XML force a specific resolver regardless of context.
+2. **Parent inheritance.** Walks `$block->getParentBlock()` until it finds an ancestor whose `magewire` data key already holds a constructed `Component`, and returns that component's `magewireResolver()`. Source of truth is the **live Component on the ancestor block**, not the persistent `ResolversCache` — so a mid-request cache flush cannot poison the choice. Solves the dynamic-load case where a child component is introduced through a parent's XHR re-render and the `LayoutLifecycle` stack doesn't reflect the full page route.
+3. **Persistent block→accessor cache** (`ResolversCache`, keyed by block cache key).
+4. **`complies()` chain.** Iterate registered resolvers by `sortOrder`; the first whose `complies()` returns true wins.
+
+For an XHR update, this whole chain is **not re-run** for components that were rendered initially: the resolver `$accessor` is dehydrated into the snapshot memo (`memo.resolver`) and reused directly by `createResolverByAccessor()` on reconstruct. Resolution only runs again for blocks that weren't constructed on the previous request.
+
+Resolvers are registered in area-scoped DI:
+
+```xml
+<!-- etc/frontend/di.xml -->
+<type name="Magewirephp\Magewire\Mechanisms\ResolveComponents\Management\ComponentResolverManager">
+    <arguments>
+        <argument name="resolvers" xsi:type="array">
+            <item name="layout" xsi:type="object" sortOrder="99900">
+                Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolver\LayoutResolver
+            </item>
+        </argument>
+    </arguments>
+</type>
+```
+
+The resolver's DI item name must match its `$accessor` property exactly. The accessor is stored in the component's snapshot memo, so subsequent requests can find the right resolver to reconstruct the component.
+
+### The Resolver Contract
+
+Every resolver extends `ComponentResolver` and implements:
+
+| Method | Purpose |
+|--------|---------|
+| `complies($block, $magewire)` | Lightweight check: does this block belong to this resolver? |
+| `construct($block)` | Initial page load: bind a `Component` instance to the block's `magewire` data key, set `name` and `id` |
+| `reconstruct($request)` | AJAX update: rebuild the block + component from snapshot data (typically calls `construct()` internally) |
+| `arguments()` | Return a `MagewireArguments` subclass for this resolver |
+| `assemble($block, $component)` | Final assembly after construct/reconstruct — sets name, id, alias on the component |
+| `remember()` | Whether this resolver should be cached (default `true`; set `false` for dynamic resolution) |
+
+```php
+namespace Vendor\Module\Mechanisms\ResolveComponents\ComponentResolver;
+
+use Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolver\ComponentResolver;
+
+class WidgetResolver extends ComponentResolver
+{
+    protected string $accessor = 'widget';
+
+    public function complies(AbstractBlock $block, mixed $magewire = null): bool
+    {
+        // Check for widget-specific data
+        $this->conditions()->if(
+            fn () => $block->getData('widget_instance_id') !== null,
+            'is-widget'
+        );
+
+        return parent::complies($block, $magewire);
+    }
+
+    public function construct(AbstractBlock $block): AbstractBlock
+    {
+        // Instantiate component and bind to block
+        $component = Factory::create(MyWidgetComponent::class);
+        $block->setData('magewire', $component);
+        return $block;
+    }
+
+    public function reconstruct(ComponentRequestContext $request): AbstractBlock
+    {
+        // Rebuild from snapshot — get widget ID from memo, recreate block
+        $widgetId = $request->snapshot->memo['widget_id'] ?? null;
+        $block = $this->widgetRepository->getBlockById($widgetId);
+        return $this->construct($block);
+    }
+
+    public function arguments(): MagewireArguments
+    {
+        return $this->widgetBlockArgumentsFactory->create();
+    }
+}
+```
+
+### ComponentArguments: Structured Block Arguments
+
+Magewire introduces a structured argument system for passing data to components through layout XML. Arguments are extracted from block data during the assembly phase.
+
+**Public arguments** — prefixed with `magewire.`, become component properties:
+
+```xml
+<block name="my.component" template="Vendor_Module::my-component.phtml">
+    <arguments>
+        <argument name="magewire" xsi:type="object">Vendor\Module\Magewire\MyComponent</argument>
+        <argument name="magewire.product-id" xsi:type="number">42</argument>
+        <argument name="magewire.sort-order" xsi:type="string">price</argument>
+    </arguments>
+</block>
+```
+
+The `magewire.` prefix is stripped and kebab-case is converted to camelCase:
+- `magewire.product-id` → `productId`
+- `magewire.sort-order` → `sortOrder`
+
+**Group arguments** — prefixed with `magewire:{group}:{key}`, organized into named groups:
+
+```xml
+<block name="my.component" template="Vendor_Module::my-component.phtml">
+    <arguments>
+        <argument name="magewire" xsi:type="object">Vendor\Module\Magewire\MyComponent</argument>
+        <argument name="magewire:mount:category-id" xsi:type="number">10</argument>
+        <argument name="magewire:mount:page-size" xsi:type="number">20</argument>
+        <argument name="magewire:config:cache-ttl" xsi:type="number">3600</argument>
+    </arguments>
+</block>
+```
+
+Group arguments are accessed via the `MagewireArguments` API:
+
+```php
+// In your component's mount() — receives the 'mount' group
+public function mount(int $categoryId = 0, int $pageSize = 10): void
+{
+    // $categoryId = 10, $pageSize = 20 (from magewire:mount:*)
+}
+
+// In a resolver or feature — access any group
+$arguments->forMount();                  // ['categoryId' => 10, 'pageSize' => 20]
+$arguments->forGroup('config');          // ['cacheTtl' => 3600]
+$arguments->toParams();                  // All public arguments as array
+```
+
+**Resolver-specific arguments** — the `magewire:resolver` key can force a specific resolver:
+
+```xml
+<argument name="magewire:resolver" xsi:type="string">widget</argument>
+```
+
+**Alias** — the `magewire:alias` key sets a component alias for lookup:
+
+```xml
+<argument name="magewire:alias" xsi:type="string">shipping-form</argument>
+```
+
+### Argument Class Hierarchy
+
+Each resolver provides its own `MagewireArguments` subclass:
+
+```
+MagewireArguments (abstract, extends DataObject)
+  └── BlockMagewireArguments
+        └── LayoutBlockArguments (used by LayoutResolver, marked shared="false" in DI)
+```
+
+Custom resolvers create their own subclass for specialized argument handling (e.g., `WidgetBlockArguments` could extract widget configuration parameters).
+
+### The Layout Resolver
+
+The built-in `LayoutResolver` (accessor: `layout`) handles the most common case — components declared in layout XML. It supports three binding formats:
+
+```xml
+<!-- 1. Direct object binding (most common) -->
+<argument name="magewire" xsi:type="object">Vendor\Module\Magewire\MyComponent</argument>
+
+<!-- 2. Array with type object (allows additional config alongside the component) -->
+<argument name="magewire" xsi:type="array">
+    <item name="type" xsi:type="object">Vendor\Module\Magewire\MyComponent</item>
+</argument>
+
+<!-- 3. Array with type boolean (dynamic component, no physical class) -->
+<argument name="magewire" xsi:type="array">
+    <item name="type" xsi:type="boolean">true</item>
+</argument>
+```
+
+On dehydrate, the `LayoutResolver` stores the active layout handles in the snapshot memo. On reconstruction (AJAX), it regenerates the layout from those handles to recover the block.
+
+### Writing a Custom Resolver
+
+To add a new component source (e.g., Magento widgets):
+
+1. Create a resolver class extending `ComponentResolver`
+2. Create a `MagewireArguments` subclass for your argument format
+3. Register in area-scoped DI with a unique accessor name and sort order
+
+```xml
+<type name="Magewirephp\Magewire\Mechanisms\ResolveComponents\Management\ComponentResolverManager">
+    <arguments>
+        <argument name="resolvers" xsi:type="array">
+            <item name="widget" xsi:type="object" sortOrder="50000">
+                Vendor\Module\Mechanisms\ResolveComponents\ComponentResolver\WidgetResolver
+            </item>
+        </argument>
+    </arguments>
+</type>
+```
+
+Lower sort orders are evaluated first. The `LayoutResolver` intentionally uses a high sort order (99900) so it acts as a fallback — custom resolvers should use lower numbers to take priority when their `complies()` check matches.
+
+---
+
+## Snapshot & State Flow
+
+The `Snapshot` is the serialized state of a component, round-tripped between frontend and backend as JSON embedded in the HTML.
+
+```
+Snapshot = {
+    data: { /* public properties */ },
+    memo: { /* metadata: resolver class, children, bindings, etc. */ },
+    checksum: /* HMAC of data+memo */
+}
+```
+
+The checksum prevents tampering. On each AJAX request, Magewire validates it before processing.
+
+`Memo` carries non-property metadata. The `ResolveComponents` mechanism writes the component resolver class name into memo so the component can be reconstructed on subsequent requests without needing layout context.
+
+`Effects` accumulates side effects during the request (redirect, events, method return values) and is sent back to the frontend alongside the new snapshot.
+
+### Synthesizers
+
+Synthesizers (in `dist/Mechanisms/HandleComponents/Synthesizers/` for ported ones, `lib/Magewire/Mechanisms/HandleComponents/Synthesizers/` for Magento-specific ones) handle serialization of non-scalar property types (e.g. `DataObject`, PHP enums, collections). To support a custom type in properties, create a synthesizer and register it in DI.
+
+---
+
+## Request Flow (AJAX Update)
+
+```
+POST magewire/update
+  → Update controller (src/Controller/Magewire/Update.php)
+  → HandleRequestFacade::update()
+  → HandleRequests mechanism
+      1. Reconstruct component from snapshot memo (resolver class)
+      2. boot() + initialize() hooks
+      3. hydrate() hooks
+      4. booted() hook
+      5. Apply property updates → updating/updated hooks
+      6. Execute method calls
+      7. rendering() hook → render template → rendered() hook
+      8. dehydrate() hooks
+      9. Generate new snapshot + checksum
+     10. Return { snapshot, effects, html }
+  ← Alpine.js morphs DOM, stores new snapshot
+```
+
+---
+
+## Layout & Template Integration
+
+Magewire's own layout is defined in `src/view/base/layout/default.xml`. It creates a `magewire` root block that outputs all setup scripts (Alpine.js init, utilities, addons, directives, feature scripts).
+
+Magewire can be bound to any block class — not just `Magewirephp\Magewire\Block\Magewire`. The `ResolveComponents` mechanism discovers all blocks with a `magewire` data argument during layout render, uses the appropriate `ComponentResolver` to instantiate the PHP component class, mounts it, and embeds the snapshot as a `wire:snapshot` attribute on the root element.
+
+### Layout Containers
+
+All Magewire layout output is organized in named containers. Extend via standard Magento layout XML:
+
+```xml
+<referenceContainer name="magewire.features">
+    <block name="my.feature.js" template="Vendor_Module::magewire-features/my-feature/my-feature.phtml"/>
+</referenceContainer>
+```
+
+Full layout reference (from `src/view/base/layout/default.xml`). Elements marked **(block)** have templates; **(container)** are injection points.
+
+| Name | Type | Purpose |
+|------|------|---------|
+| `magewire` | block | Root block (`root.phtml`) |
+| `magewire.global` | block | Global JS setup (`js/magewire/global.phtml`) |
+| `magewire.global.before` | container | Before global — holds Alpine load, Alpine code, Alpine components |
+| `magewire.alpinejs.load` | container | Alpine JS loading |
+| `magewire.alpinejs` | container | Custom Alpine JS code (before Magewire Alpine) |
+| `magewire.alpinejs.components` | container | Alpine `Alpine.data()` registrations |
+| `magewire.utilities` | block | Utility parent (`js/magewire/utilities.phtml`) — renders child utilities |
+| `magewire.utilities.after` | container | Inject custom utilities after core ones |
+| `magewire.addons` | block | Addon parent (`js/magewire/addons.phtml`) — renders child addons |
+| `magewire.addons.after` | container | Inject custom addons after core ones |
+| `magewire.global.after` | container | Custom extensions after the global block |
+| `magewire.before` | container | Holds Alpine directives, UI components, Alpine after |
+| `magewire.alpinejs.directives` | container | Custom Alpine directives |
+| `magewire.ui-components` | container | Alpine UI components (notifier lives here) |
+| `magewire.alpinejs.after` | container | Custom Alpine code after Magewire Alpine code |
+| `magewire.before.internal` | container | Debug state blocks |
+| `magewire.internal` | block | Non-overridable core block — do not inject here |
+| `magewire.internal.backwards-compatibility` | container | BC injection point inside internal block |
+| `magewire.directives` | block | Directive parent (`js/magewire/directives.phtml`) — renders child directives |
+| `magewire.features` | block | Feature parent (`js/magewire/features.phtml`) — renders child feature scripts |
+| `magewire.after.internal` | container | Inject content after the internal block |
+| `magewire.disabled` | container | Renders only when Magewire is inactive |
+| `magewire.after` | container | Everything else (debug tools, HTML blocks) |
+| `magewire.legacy` | container | V1 backwards compatibility — do not use for new code |
+
+Note: `magewire.utilities`, `magewire.addons`, `magewire.directives`, and `magewire.features` are **blocks** (not containers). They have parent templates that call `$block->getChildHtml()` to render their children. Add custom children as blocks inside them.
+
+---
+
+## JavaScript Architecture
+
+**All JavaScript must be CSP-compliant.** Never use raw `<script>` tags in templates. All inline scripts must use the fragment utility (`$magewireFragment->make()->script()->start()/end()`), which automatically handles CSP nonce or hash injection depending on the Magento configuration:
+- **With Full Page Cache:** generates a SHA256 hash of the script content and adds it to the `script-src` CSP header
+- **Without FPC:** adds a `nonce` attribute via Magento's `CspNonceProvider`
+
+The JS bundle (`magewire.csp.min.js`) is Livewire's JavaScript copied directly, without any modifications.
+It is served as a Magento static asset via the `FrontendAssets` mechanism, with version pinning via `manifest.json`.
+Keeping it untouched is intentional — Livewire bug fixes and feature releases can be adopted simply by replacing the file.
+
+The bundle (all Livewire's own code) handles:
+- Alpine.js plugin registration
+- `wire:*` directive processing
+- Snapshot management and AJAX lifecycle
+- DOM morphing
+- Effect processing (redirects, events, DOM patches)
+
+**Inline setup scripts** (PHTML templates in `view/base/templates/js/magewire/`) handle:
+- `global.phtml` — Defines `MagewireResource`, `window.MagewireAddons`, `window.MagewireUtilities` (must be inline, runs before deferred bundle)
+- `i18n.phtml` — Outputs `window.MagewireI18n` translation map
+- `features.phtml` — Loads the external deferred feature bundle
+
+These inline scripts run synchronously before the deferred bundle, establishing the global API that the bundle and feature scripts depend on.
+
+---
+
+## Facades (Experimental)
+
+Facades provide a simplified entry point into a Feature or Mechanism's API, abstracting internal complexity.
+
+Register via `di.xml` using the `facade` key:
+
+```xml
+<item name="my_feature" xsi:type="array">
+    <item name="type" xsi:type="string">Vendor\Module\Features\MyFeature</item>
+    <item name="facade" xsi:type="string">Vendor\Module\Features\MyFeature\MyFeatureFacade</item>
+</item>
+```
+
+Access via the service provider's magic getter:
+
+```php
+$facade = $magewireServiceProvider->getMyFeatureFacade();
+```
+
+Facades live in their feature/mechanism's own subdirectory. This feature is experimental and may change.
+
+---
+
+## Augmenting Ported Code
+
+`dist/` (configurable via `directories.output` in `portman.config.php`, defaults to `dist/`) is Portman-generated and must not be edited directly. To override or extend a ported Livewire class:
+
+1. Create a matching file in `portman/Livewire/` with the same relative path as the file in `lib/Livewire/`
+2. Define a class with the same name using the **source** namespace (`Livewire\`) — Portman merges its methods and properties into the source class at build time
+3. Run `vendor/bin/portman build` to regenerate `dist/`
+
+For Magento-level overrides (plugins, preferences), use standard Magento DI on the generated class in `dist/`.
+
+---
+
+## Adding a New Compatibility Module
+
+Magewire ships with compatibility modules for Hyva, Luma, Breeze, and Admin (e.g. `Magewirephp_MagewireCompatibilityWithHyva`). These are separate Magento modules that extend Magewire behavior for a specific frontend stack.
+
+Pattern:
+- Declare dependency on `Magewirephp_Magewire` in `module.xml`
+- Register additional Features or Mechanisms via DI
+- Override or extend layout XML blocks for the target theme
+- Add theme-specific JS/PHTML as needed

--- a/.agents/skills/magewire-backwards-compatibility/SKILL.md
+++ b/.agents/skills/magewire-backwards-compatibility/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: magewire-backwards-compatibility
+description: "Reference for Magewire's framework-level backwards compatibility system. Use when migrating Magewire v1 (Livewire v2) code to v3, enabling BC on components, understanding wire:model / entangle / hook behavioral changes between v2 and v3, or working with the BC memo flag, deprecated v1 component APIs, and the #[HandleBackwardsCompatibility] attribute. Theme-agnostic — BC applies to any Magewire component in any Magento theme. For theme-specific BC JS implementations (e.g. Hyvä Checkout), see the matching theme's BC skill."
+license: MIT
+metadata:
+  author: Willem Poortman
+---
+
+# Magewire Backwards Compatibility
+
+Magewire v3 is built on Livewire v3, which introduced breaking changes from v2. The BC system lets existing v1 components keep working without code changes while providing a migration path to v3 conventions.
+
+Magewire is **not tied to any specific theme**. The BC system is a framework concern — any component, in any theme, can opt into BC. Individual themes may ship their own JS-layer BC implementations on top of this core (see the theme's BC skill for details).
+
+---
+
+## The Two BC Layers
+
+### 1. Core BC (`lib/MagewireBc/`) — theme-agnostic
+
+Framework-level compatibility that applies to all Magewire components regardless of theme.
+
+**PHP trait** — `HandlesComponentBackwardsCompatibility` is mixed into the base `Component` class. It provides deprecated v1 APIs: `$this->id` (public), `getPublicProperties()`, and concerns for Emit, Error, BrowserEvent, and Request. The `Component\Form` base class uses this trait via `HandlesFormComponentBackwardsCompatibility` (a deprecated pass-through that exists for potential form-specific BC, currently empty).
+
+**Feature** — `SupportMagewireBackwardsCompatibility` (sort order 99100):
+- Pushes BC effects into the snapshot during `dehydrate()`: property path mappings (`data` → `$wire`, `__livewire` → `queuedUpdates`) and preferences
+- These effects are read by JS to proxy old property access patterns
+
+### 2. Theme-specific BC layers
+
+Some themes need additional BC on top of core — wire directive rewriting, entangle live-by-default, deprecated JS hook/event re-triggering. Those live in the theme's own module under `themes/{Theme}/` and are documented in that theme's BC skill. The pattern is always the same:
+
+- A theme-scoped Feature manages a `memo.bc.enabled` flag on the snapshot
+- JS templates read the flag and apply migrations to components that have it set
+- The flag is resolvable per-component via the `#[HandleBackwardsCompatibility]` attribute, data store, or theme-defined layout rules
+
+---
+
+## The `memo.bc.enabled` Flag
+
+The BC flag is the single signal a theme's BC JS uses to decide whether to apply v2→v3 shims to a component. Resolution priority:
+
+1. `#[HandleBackwardsCompatibility]` attribute on the component class
+2. Previously hydrated value from the component's data store
+3. Theme-specific defaults (e.g. "all components under layout container X")
+
+On `hydrate()`, the flag is restored from memo into the component's data store. On `dehydrate()`, it is pushed back into the snapshot memo.
+
+---
+
+## Wire Directive Changes (v2 → v3)
+
+| Livewire v2 | Livewire v3 | Behavior |
+|---|---|---|
+| `wire:model` | `wire:model.live` | Syncs on every input change (instant) |
+| `wire:model.defer` | `wire:model` | Syncs on form submit / next request (now the default) |
+| `wire:model.lazy` | `wire:model.blur` | Syncs when the field loses focus |
+
+### Migrating your own code
+
+Remove the old modifiers and use v3 syntax:
+
+```html
+<!-- Before (v1/v2) -->
+<input wire:model="name">              <!-- instant sync -->
+<input wire:model.defer="email">       <!-- deferred -->
+<input wire:model.lazy="phone">        <!-- on blur -->
+
+<!-- After (v3) -->
+<input wire:model.live="name">         <!-- instant sync (opt-in) -->
+<input wire:model="email">             <!-- deferred (now default) -->
+<input wire:model.blur="phone">        <!-- on blur -->
+```
+
+A theme's BC JS may rewrite these directives automatically for components with `memo.bc.enabled` — see that theme's BC skill.
+
+---
+
+## Entangle Changes (v2 → v3)
+
+| Livewire v2 | Livewire v3 |
+|---|---|
+| `$wire.entangle('prop')` — **live** by default | `$wire.entangle('prop')` — **deferred** by default |
+| N/A | `$wire.entangle('prop').live` — opt-in to live |
+
+### Migrating your own code
+
+If you want instant sync (v2 default), add `.live` explicitly:
+
+```javascript
+// Before (v1/v2) — live by default
+couponCode: this.$wire.entangle('couponCode'),
+
+// After (v3) — must opt in to live
+couponCode: this.$wire.entangle('couponCode').live,
+
+// Or keep deferred (v3 default) — no .live needed
+couponCode: this.$wire.entangle('couponCode'),
+```
+
+A theme's BC JS may restore the v2 live-by-default semantic for BC-enabled components via a `$wire` proxy — see that theme's BC skill.
+
+---
+
+## Hook / Event Changes (v2 → v3)
+
+| Deprecated (v2) | Replacement (v3) |
+|---|---|
+| `component.initialized` | `component.init` |
+| `element.initialized` | `element.init` |
+| `element.updating` | `morph.updating` |
+| `element.removed` | `morph.removed` |
+| `message.sent` | `commit` |
+| `message.failed` | `commit` → `fail()` |
+| `message.received` | `commit` → `succeed()` |
+| `message.processed` | `commit` → `succeed()` → `queueMicrotask` |
+
+### Component property aliases
+
+Old property names aliased on the component object by BC JS layers:
+
+```javascript
+// component.deferredActions → component.queuedUpdates
+// component.data → component.$wire
+```
+
+---
+
+## Enabling BC for a Component
+
+### Explicit via PHP attribute
+
+```php
+use Magewirephp\Magewire\Features\SupportMagewireBackwardsCompatibility\HandleBackwardsCompatibility;
+
+#[HandleBackwardsCompatibility]
+class MyLegacyComponent extends Component
+{
+    // This component gets BC behavior
+}
+
+#[HandleBackwardsCompatibility(enabled: false)]
+class MyModernComponent extends Component
+{
+    // Explicitly opt out, even if a theme would normally enable it
+}
+```
+
+### Via data store (programmatic)
+
+```php
+use function Magewirephp\Magewire\store;
+
+// In a Feature or hook:
+store($component)->set('bc.enabled', true);
+```
+
+### Via theme defaults
+
+A theme can decide to BC-enable components automatically based on its own rules (e.g. layout container membership). See the target theme's BC skill.
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/MagewireBc/Features/SupportMagewireBackwardsCompatibility/SupportMagewireBackwardsCompatibility.php` | Core BC feature — pushes path mappings into effects |
+| `lib/MagewireBc/Features/SupportMagewireBackwardsCompatibility/HandleBackwardsCompatibility.php` | PHP attribute for explicit BC opt-in/out |
+| `lib/MagewireBc/Features/SupportMagewireBackwardsCompatibility/HandlesComponentBackwardsCompatibility.php` | Trait with deprecated v1 component APIs |
+
+---
+
+## Migration Checklist
+
+When upgrading a v1 component to v3:
+
+1. **wire:model** — replace `wire:model` with `wire:model.live` if you need instant sync, remove `.defer` (it's now the default), replace `.lazy` with `.blur`
+2. **entangle** — add `.live` if you need instant sync, otherwise leave as-is (deferred is now default)
+3. **JS hooks** — replace deprecated event names (see table above)
+4. **Component properties** — replace `component.data` with `component.$wire`, `component.deferredActions` with `component.queuedUpdates`
+5. **PHP APIs** — replace `$this->getPublicProperties()` with `$this->all()`, avoid public `$this->id` (use `$this->id()` or `$this->getId()`)
+6. **Remove BC attribute** — once migrated, remove `#[HandleBackwardsCompatibility]` if present

--- a/.agents/skills/magewire-best-practices/SKILL.md
+++ b/.agents/skills/magewire-best-practices/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: magewire-best-practices
+description: "Use when writing, reviewing, or refactoring Magewire code for Magento 2 — components, PHTML templates, layout XML, DI configuration, Features, Mechanisms, synthesizers, lifecycle hooks, event handling, and JavaScript integration. Trigger phrases include: component design, property handling, security patterns, template rendering, DI registration, snapshot serialization, state management, architectural decisions. Also use for Magewire code reviews and refactoring. Covers any task involving Magewire PHP or JS patterns within Magento 2."
+requires: magewire, magewire-architecture, magewire-javascript
+license: MIT
+metadata:
+  author: Willem Poortman
+---
+
+# Magewire Best Practices
+
+Best practices for Magewire development in Magento 2, prioritized by impact. Each rule teaches what to do and why. For deeper API reference, load the `magewire`, `magewire-architecture`, or `magewire-javascript` skills.
+
+## Consistency First
+
+Before applying any rule, check what the codebase already does. Magewire bridges two ecosystems — Magento and Livewire — and both offer multiple valid approaches. The best choice is the one the codebase already uses, even if another pattern would be theoretically better. Inconsistency is worse than a suboptimal pattern.
+
+Check sibling components, related Features, existing DI config, and neighboring templates for established patterns. If one exists, follow it — don't introduce a second way. These rules are defaults for when no pattern exists yet, not overrides.
+
+## Quick Reference
+
+### 1. Component Design → `references/components.md`
+
+- Extend `Magewirephp\Magewire\Component`, not Magento block classes
+- Keep public properties serializable — scalars, arrays, or types with a registered synthesizer
+- Use typed properties with defaults — uninitialized properties break snapshot serialization
+- Small, focused components — split large components into parent-child
+- Never query the database in the constructor — use `mount()` for initialization
+- Use `$this->skipRender()` when a method only changes state without needing a re-render
+
+### 2. Properties & State → `references/properties.md`
+
+- Scalar types and arrays for public properties — complex objects need synthesizers
+- `wire:model` for form binding, `wire:model.live` only when instant feedback is required
+- `fill()` accepts arrays and DataObjects — use it for bulk property assignment
+- `reset()` and `resetExcept()` to restore initial state cleanly
+- Dot notation (`address.city`) for nested array/object properties
+- Never store sensitive data (passwords, tokens) in public properties — they travel to the client
+
+### 3. Lifecycle Hooks → `references/lifecycle.md`
+
+- `mount()` for initial setup — runs once, receives layout XML arguments
+- `boot()` / `booted()` for every-request setup — use for authorization checks
+- `hydrate()` / `dehydrate()` for request boundary logic, not business logic
+- `updating()` / `updated()` for validation and side effects on property changes
+- Property-specific hooks (`updatingName`, `updatedName`) over generic hooks when targeting one property
+- Never call `$this->render()` manually — the framework handles the render cycle
+
+### 4. Templates & Views → `references/templates.md`
+
+- Single root element required in every component template
+- `$magewire` is the component instance — access properties and methods directly
+- `$escaper->escapeHtml()`, `$escaper->escapeUrl()`, `$escaper->escapeJs()` for all dynamic output
+- `$block->getChildHtml()` for nested Magento blocks inside a Magewire template
+- Never echo raw user input — use Magento's escaper, not PHP's `htmlspecialchars()`
+- Keep templates thin — logic belongs in the component class, not in PHTML
+
+### 5. Layout XML & Block Registration → `references/layout.md`
+
+- Component class goes in `<argument name="magewire">` — Magewire can be bound to any block class
+- Use `name` attribute for unique block identification — Magento merges by name
+- Template path uses module notation: `Vendor_Module::template.phtml`
+- Register blocks within the page layout handle where they're needed, not globally
+
+### 6. Dependency Injection → `references/di.md`
+
+- Features and Mechanisms in area-scoped DI only (`etc/frontend/di.xml`, `etc/adminhtml/di.xml`) — never global `etc/di.xml`
+- Sort order determines boot sequence — check existing registrations before choosing a number
+- Use `boot_mode` to control when a service boots: `10` (lazy), `20` (persistent), `30` (always, default)
+- Constructor injection via Magento DI for component dependencies — not `ObjectManager::getInstance()`
+- Virtual types for DI-only variations — don't create empty subclasses
+
+### 7. Security → `references/security.md`
+
+- CSRF is automatic — Magewire uses Magento's FormKey, no manual token handling needed
+- Snapshot checksums prevent state tampering — never bypass checksum validation
+- Escape all output in templates — `$escaper->escapeHtml()` is the default, use specific escapers for URLs, JS, attributes
+- Public methods are callable from the frontend — never expose admin actions or destructive operations without authorization
+- Public properties are visible to the client — never store secrets, API keys, or session data
+- Rate limiting is handled by the `SupportMagewireRateLimiting` feature via configuration, not attributes
+
+### 8. Events & Communication → `references/events.md`
+
+- `$this->dispatch('event-name')` for cross-component communication
+- `#[On('event-name')]` attribute for declarative listeners — preferred over `$listeners` array
+- `->self()` to scope events to the dispatching component only
+- `->up()` to dispatch to the parent component
+- Kebab-case event names (`cart-updated`, not `cartUpdated`)
+- Don't use events for parent-to-child — pass data via layout XML arguments or properties
+
+### 9. JavaScript Integration → `references/javascript.md`
+
+- CSP-compatible scripts only — use `$magewireFragment->make()->script()->start()/end()`, never raw `<script>` tags
+- `magewire:init` for Magewire hooks, `alpine:init` for Alpine registrations, `magewire:initialized` for directives
+- Always `{ once: true }` on registration event listeners to prevent double registration
+- Access addons via `window.MagewireAddons`, utilities via `window.MagewireUtilities`
+- Guard addon access with `addons.has('name')` — addons are optional
+- Never depend on `window.Magewire` at registration time — it may not exist yet
+
+### 10. Features & Extensions → `references/features.md`
+
+- Extend `ComponentHook` for lifecycle-based extensions — implement only the hooks you need
+- `SupportMagewire*` prefix for Magewire-specific features, `SupportMagento*` for Magento bridge features
+- Feature-owned JS/templates live in the feature's folder, not in global `addons/` or `components/`
+- Use `storeSet()` / `storeGet()` for component-scoped feature state — not class properties
+- Push side effects via `$context->pushEffect()` during `dehydrate()` — never echo output from features
+- Facades for public APIs — register with `facade` key in DI config
+
+### 11. Performance → `references/performance.md`
+
+- `$this->skipRender()` when a method call doesn't need to update the DOM
+- Avoid `wire:model.live` on high-frequency inputs — use `wire:model.blur` or debounce
+- Minimize public properties — every property is serialized on every request
+- Lazy-load heavy dependencies — use `boot_mode: 10` for features not always needed
+- `wire:loading` for user feedback instead of polling or repeated requests
+
+### 12. Serialization & Synthesizers → `references/synthesizers.md`
+
+- Built-in synthesizers handle: arrays, stdClass, enums, floats, ints, DataObjects
+- Custom synthesizers for unsupported types — implement `match()`, `dehydrate()`, `hydrate()`
+- Register synthesizers in area-scoped DI with a sort order — first match wins
+- `dehydrate()` must return JSON-safe data — no objects, no resources
+- Test round-trip serialization: `hydrate(dehydrate($value))` must produce the original value
+- Avoid storing Magento models directly — extract needed data into scalar properties
+
+### 13. Conventions & Style → `references/style.md`
+
+- Component classes in `Vendor\Module\Magewire\` namespace — not in `Block\`, `Model\`, or `Controller\`
+- One component class per file, named after the component
+- `snake_case` for layout XML block names: `checkout.shipping.address`
+- `kebab-case` for event names and wire directives: `cart-updated`, `wire:click`
+- `PascalCase` for component class names, `camelCase` for methods and properties
+- Template files match the component purpose, not the class name: `shipping-address.phtml`, not `ShippingAddress.phtml`
+- Feature classes always prefixed with `Support`: `SupportMyFeature`
+
+## How to Apply
+
+1. Identify the file type and select relevant sections (e.g., component → 1, 2, 3; template → 4, 7; DI config → 6; JS → 9)
+2. Check sibling files for existing patterns — follow those first per Consistency First
+3. For API syntax, load the `magewire` skill for component API or `magewire-architecture` for internals

--- a/.agents/skills/magewire-best-practices/references/components.md
+++ b/.agents/skills/magewire-best-practices/references/components.md
@@ -1,0 +1,121 @@
+# Component Design
+
+## Extend the Correct Base Class
+
+Always extend `Magewirephp\Magewire\Component`. Never extend Magento block classes (`AbstractBlock`, `Template`) — Magewire handles the block layer internally via `Magewirephp\Magewire\Block\Magewire`.
+
+```php
+// Correct
+namespace Vendor\Module\Magewire;
+
+use Magewirephp\Magewire\Component;
+
+class ShippingAddress extends Component
+{
+    public string $city = '';
+}
+```
+
+```php
+// Wrong — extending a Magento block class
+use Magento\Framework\View\Element\Template;
+
+class ShippingAddress extends Template { }
+```
+
+## Use Typed Properties with Defaults
+
+Every public property must have a type declaration and a default value. Uninitialized properties break snapshot serialization because the framework cannot determine the expected type when hydrating from JSON.
+
+```php
+// Correct
+public string $name = '';
+public int $quantity = 1;
+public array $items = [];
+public bool $active = false;
+
+// Wrong — no type or no default
+public $name;
+public string $email;
+```
+
+## Keep Components Small and Focused
+
+A component should represent one interactive unit. If a component grows beyond ~10 public properties or ~5 public methods, split it into parent-child components. The parent coordinates, the children handle specific concerns.
+
+```php
+// Correct — focused component
+class ShippingMethod extends Component
+{
+    public string $selectedMethod = '';
+    public array $availableMethods = [];
+
+    public function select(string $method): void
+    {
+        $this->selectedMethod = $method;
+        $this->dispatch('shipping-method-selected', method: $method);
+    }
+}
+```
+
+## Initialize in `mount()`, Not the Constructor
+
+The constructor is called during hydration (every request). Use `mount()` for one-time initialization logic — it only runs on the initial render.
+
+```php
+// Correct
+public function mount(array $params): void
+{
+    $this->items = $this->itemRepository->getList($params['category_id']);
+}
+
+// Wrong — runs on every request, not just the first
+public function __construct(ItemRepository $itemRepository)
+{
+    $this->items = $itemRepository->getAll();
+}
+```
+
+Constructor injection via Magento DI is fine for injecting dependencies — just don't execute initialization logic there.
+
+## Use `skipRender()` for State-Only Updates
+
+When a method only changes internal state without needing to update the DOM, call `$this->skipRender()` to avoid an unnecessary re-render cycle.
+
+```php
+public function addToCompare(int $productId): void
+{
+    $this->compareList[] = $productId;
+    $this->skipRender(); // No visual change needed yet
+}
+```
+
+## Inject Dependencies via Magento DI
+
+Use constructor injection for services your component needs. Magento's DI handles instantiation.
+
+```php
+class ProductSearch extends Component
+{
+    public string $query = '';
+    public array $results = [];
+
+    public function __construct(
+        private readonly ProductRepositoryInterface $productRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {}
+
+    public function search(): void
+    {
+        $criteria = $this->searchCriteriaBuilder
+            ->addFilter('name', "%{$this->query}%", 'like')
+            ->create();
+
+        $this->results = $this->productRepository
+            ->getList($criteria)
+            ->getItems();
+    }
+}
+```
+
+Never use `ObjectManager::getInstance()` directly in component code.

--- a/.agents/skills/magewire-best-practices/references/di.md
+++ b/.agents/skills/magewire-best-practices/references/di.md
@@ -1,0 +1,84 @@
+# Dependency Injection
+
+## Area-Scoped DI for Features and Mechanisms
+
+Features and Mechanisms must be registered in area-scoped DI files — `etc/frontend/di.xml` or `etc/adminhtml/di.xml` — never in the global `etc/di.xml`.
+
+**Why:** Magento merges global DI config into every area. A Feature registered globally cannot be selectively disabled or replaced per area. Area-scoped registration allows frontend and admin to have different Feature sets, and lets theme compatibility modules override Features cleanly.
+
+For the DI XML registration format, see the **Adding a Custom Feature** section in the `magewire-architecture` skill.
+
+## Choose Sort Order Carefully
+
+Sort order determines boot sequence and hook execution order. Check existing registrations before picking a number — collisions cause unpredictable behavior.
+
+| Range | Convention |
+|-------|-----------|
+| 700–1600 | Core features (view model, exceptions, events, attributes) |
+| 5000–5999 | Magento integration features (layouts, flash messages, loaders, notifications) |
+| 99000–99999 | Late-stage lifecycle features (lifecycle hooks, backwards compatibility) |
+
+Pick a number that places your feature in the correct execution phase relative to what it depends on.
+
+## Use `boot_mode` Intentionally
+
+```xml
+<item name="my_feature" xsi:type="array">
+    <item name="type" xsi:type="string">Vendor\Module\Features\SupportMyFeature</item>
+    <item name="sort_order" xsi:type="number">5050</item>
+    <item name="boot_mode" xsi:type="number">10</item> <!-- LAZY -->
+</item>
+```
+
+| Mode | Value | Behavior |
+|------|-------|----------|
+| LAZY | 10 | Boots only when explicitly needed — use for rarely-triggered features |
+| PERSISTENT | 20 | Boots during setup phase, persists across request modes — use for features that need early initialization |
+| ALWAYS | 30 | Boots on every request (default) — use for features that must always be active |
+
+Default is ALWAYS (30). Only override when you have a specific reason to defer or persist.
+
+## Constructor Injection for Component Dependencies
+
+Components are Magento DI-managed objects. Use constructor injection for services.
+
+```php
+class OrderHistory extends Component
+{
+    public array $orders = [];
+
+    public function __construct(
+        private readonly OrderRepositoryInterface $orderRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {}
+
+    public function mount(): void
+    {
+        $this->orders = $this->loadOrders();
+    }
+}
+```
+
+Never use `ObjectManager::getInstance()` in component code. If you need a service that isn't available through DI, fix the DI configuration rather than working around it.
+
+## Virtual Types for Configuration Variants
+
+When you need the same Feature class with different configuration, use Magento virtual types instead of creating empty subclasses.
+
+```xml
+<!-- Correct — virtual type for a configured variant -->
+<virtualType name="Vendor\Module\Features\SupportMyFeatureWithLogging"
+             type="Vendor\Module\Features\SupportMyFeature">
+    <arguments>
+        <argument name="enableLogging" xsi:type="boolean">true</argument>
+    </arguments>
+</virtualType>
+
+<!-- Wrong — empty subclass just for DI config -->
+```
+
+## Register Synthesizers in Area-Scoped DI
+
+Custom synthesizers follow the same area-scoped rule. Register them under the `HandleComponents` mechanism config. Sort order matters — the first synthesizer whose `match()` returns true wins.
+
+See `references/synthesizers.md` and the `magewire-architecture` skill for the registration format.

--- a/.agents/skills/magewire-best-practices/references/events.md
+++ b/.agents/skills/magewire-best-practices/references/events.md
@@ -1,0 +1,99 @@
+# Events & Communication
+
+## Use `dispatch()` for Cross-Component Communication
+
+Components communicate via events. The dispatching component fires, listeners on other components react.
+
+```php
+// Dispatch from one component
+public function addToCart(int $productId): void
+{
+    $this->cartService->add($productId);
+    $this->dispatch('cart-updated', itemCount: $this->getCartCount());
+}
+```
+
+```php
+// Listen in another component
+#[On('cart-updated')]
+public function onCartUpdated(int $itemCount): void
+{
+    $this->cartCount = $itemCount;
+}
+```
+
+## Prefer `#[On()]` Over `$listeners`
+
+The `#[On()]` attribute is declarative, co-located with the handler method, and easier to find when reading code. Use it over the `$listeners` property array.
+
+```php
+// Preferred
+#[On('cart-updated')]
+public function refreshCart(int $itemCount): void
+{
+    $this->itemCount = $itemCount;
+}
+
+// Acceptable but less clear
+protected $listeners = ['cart-updated' => 'refreshCart'];
+
+public function refreshCart(int $itemCount): void
+{
+    $this->itemCount = $itemCount;
+}
+```
+
+## Use Kebab-Case Event Names
+
+Event names should be `kebab-case`, consistent with HTML attribute conventions and `wire:` directive naming.
+
+```php
+// Correct
+$this->dispatch('shipping-method-selected');
+$this->dispatch('payment-form-validated');
+
+// Wrong
+$this->dispatch('shippingMethodSelected');
+$this->dispatch('PAYMENT_VALIDATED');
+```
+
+## Scope Events Appropriately
+
+| Method | Scope | Use when |
+|--------|-------|----------|
+| `$this->dispatch('name')` | All components on the page | Broadcasting to any interested listener |
+| `$this->dispatch('name')->self()` | Only the dispatching component | Internal state management, self-refresh |
+| `$this->dispatch('name')->up()` | Parent component only | Child-to-parent communication |
+| `$this->dispatch('name')->to(Component::class)` | Specific component type | Targeted updates |
+
+Default to the narrowest scope that works. Broadcasting to all components when only the parent needs the event wastes processing.
+
+## Don't Use Events for Parent-to-Child Data Flow
+
+If a parent needs to pass data to a child, use layout XML arguments (for initial data) or public properties on the child that the parent sets. Events are for decoupled, sibling-to-sibling or child-to-parent communication.
+
+```php
+// Wrong — parent dispatching to child
+public function selectCategory(int $id): void
+{
+    $this->selectedCategory = $id;
+    $this->dispatch('category-selected', categoryId: $id); // Unnecessary
+}
+
+// Correct — child reads parent state via its own properties
+// Layout XML nests the child inside the parent, and the child
+// receives data through its mount() parameters or re-renders
+// when the parent re-renders.
+```
+
+## Keep Event Payloads Serializable
+
+Event data travels through JavaScript. Only pass scalar values and simple arrays — no objects, no Magento models.
+
+```php
+// Correct
+$this->dispatch('order-placed', orderId: $order->getId(), total: (float) $order->getGrandTotal());
+
+// Wrong — object not serializable to JSON
+$this->dispatch('order-placed', order: $order);
+```

--- a/.agents/skills/magewire-best-practices/references/features.md
+++ b/.agents/skills/magewire-best-practices/references/features.md
@@ -1,0 +1,119 @@
+# Features & Extensions
+
+## Extend `ComponentHook`
+
+Every Feature is a `ComponentHook` subclass that hooks into the component lifecycle via `provide()`. Implement only the hooks you need — don't stub hooks you won't use.
+
+For the full class boilerplate, middleware-pattern hooks, and the list of available lifecycle signals, see the **Features** section in the `magewire-architecture` skill.
+
+## Follow Naming Conventions
+
+| Prefix | Meaning | Example |
+|--------|---------|---------|
+| `SupportMagewire*` | Magewire-specific feature | `SupportMagewireLoaders`, `SupportMagewireNotifications` |
+| `SupportMagento*` | Magento bridge/integration | `SupportMagentoLayouts`, `SupportMagentoFlashMessages` |
+| `Support*` | Ported from Livewire | `SupportEvents`, `SupportAttributes`, `SupportRedirects` |
+
+Third-party features should use `SupportMagewire*` or `SupportMagento*` depending on whether they extend Magewire functionality or bridge a Magento subsystem.
+
+## Use `storeSet()` / `storeGet()` for Feature State
+
+Features should not use class properties for component-scoped state — the same Feature instance may serve multiple components. Use the component-scoped data store instead.
+
+```php
+on('mount', function () {
+    // Store data scoped to this specific component
+    $this->storeSet('initialized', true);
+});
+
+on('dehydrate', function ($context) {
+    if ($this->storeGet('initialized')) {
+        $context->pushEffect('myFeature', ['ready' => true]);
+    }
+});
+```
+
+## Push Effects During `dehydrate()`
+
+Side effects (data sent to the frontend) must be pushed via `$context->pushEffect()` during the dehydrate phase — not by echoing output or modifying the response directly.
+
+```php
+on('dehydrate', function ($context) {
+    $messages = $this->collectPendingMessages();
+
+    if (!empty($messages)) {
+        $context->pushEffect('notifications', $messages);
+    }
+});
+```
+
+The frontend feature bridge script then reads effects from the commit response:
+
+```javascript
+Magewire.hook('commit', function({ succeed }) {
+    succeed(function({ effects }) {
+        if (effects.notifications) {
+            window.MagewireAddons.notifier.create(effects.notifications);
+        }
+    });
+});
+```
+
+## Feature-Owned Assets Live in the Feature Folder
+
+When a Feature has its own JavaScript, Alpine component, or HTML template, place them inside the feature's directory — not in the global `addons/`, `components/`, or `ui-components/` directories.
+
+```
+view/{area}/templates/magewire-features/support-my-feature/
+├── support-my-feature.phtml      ← Primary bridge script
+├── addon.phtml                   ← Feature-owned addon (if needed)
+└── component.phtml               ← Feature-owned Alpine component (if needed)
+```
+
+Global `addons/` and `alpinejs/components/` are reserved for standalone components that work independently of any specific Feature.
+
+## Register via Layout as Child Blocks
+
+Feature scripts go in the `magewire.features` container. If a feature has multiple PHTML files, register the primary as the parent and extras as child blocks.
+
+```xml
+<referenceContainer name="magewire.features">
+    <block name="magewire.features.support-my-feature"
+           template="Vendor_Module::magewire-features/support-my-feature/support-my-feature.phtml">
+        <block name="magewire.features.support-my-feature.addon"
+               as="addon"
+               template="Vendor_Module::magewire-features/support-my-feature/addon.phtml"/>
+    </block>
+</referenceContainer>
+```
+
+The primary PHTML renders children first, then its own bridge script:
+
+```php
+<?= $block->getChildHtml('addon') ?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    // Bridge script
+</script>
+<?php $script->end() ?>
+```
+
+## Facades for Public APIs
+
+When a Feature or Mechanism needs a public API that other modules consume, register a Facade via DI.
+
+```xml
+<item name="my_feature" xsi:type="array">
+    <item name="type" xsi:type="string">Vendor\Module\Features\SupportMyFeature</item>
+    <item name="facade" xsi:type="string">Vendor\Module\Features\SupportMyFeature\MyFeatureFacade</item>
+    <item name="sort_order" xsi:type="number">5050</item>
+</item>
+```
+
+Access via the service provider:
+
+```php
+$facade = $magewireServiceProvider->getMyFeatureFacade();
+```
+
+Facades live in their feature's subdirectory. This pattern is experimental — check the `magewire-architecture` skill for current status.

--- a/.agents/skills/magewire-best-practices/references/javascript.md
+++ b/.agents/skills/magewire-best-practices/references/javascript.md
@@ -1,0 +1,101 @@
+# JavaScript Integration
+
+## CSP-Compatible Scripts Only
+
+All inline JavaScript must use the fragment utility (`$magewireFragment->make()->script()->start()/end()`). Never write raw `<script>` tags — they violate Magento's Content Security Policy. The fragment mechanism handles CSP nonce/hash injection automatically.
+
+For the full PHP boilerplate and the reasons behind each step, see the `magewire-javascript` skill.
+
+## Use the Correct Event for Registration
+
+| Event | When | Use for |
+|-------|------|---------|
+| `alpine:init` | Alpine starts, before DOM walk | `Alpine.data()`, `Alpine.store()`, `Alpine.bind()`, utility registration |
+| `magewire:init` | Magewire runtime ready | Magewire hooks (`commit`, `request`), feature bridge scripts |
+| `magewire:initialized` | Full initialization complete | `Magewire.directive()` registration |
+
+```javascript
+// Alpine component registration
+document.addEventListener('alpine:init', () => Alpine.data('myComponent', myComponent), { once: true });
+
+// Magewire hook
+document.addEventListener('magewire:init', function() {
+    Magewire.hook('commit', function({ succeed }) {
+        succeed(function({ effects }) {
+            // Process effects
+        });
+    });
+}, { once: true });
+
+// Custom directive
+document.addEventListener('magewire:initialized', event => {
+    Magewire.directive('mage:my-directive', ({ el, directive, cleanup }) => {
+        // Directive logic
+        cleanup(() => { /* teardown */ });
+    });
+});
+```
+
+## Always Use `{ once: true }`
+
+Registration event listeners must use `{ once: true }` to prevent double registration on navigations or re-hydrations.
+
+```javascript
+// Correct
+document.addEventListener('alpine:init', () => { /* ... */ }, { once: true });
+
+// Wrong — may fire multiple times
+document.addEventListener('alpine:init', () => { /* ... */ });
+```
+
+## Guard Optional Dependencies
+
+Addons, utilities, and Magewire itself may not be available when your code runs. Always check before accessing.
+
+```javascript
+document.addEventListener('magewire:init', function() {
+    const addons = window.MagewireAddons;
+
+    Magewire.hook('commit', function({ succeed }) {
+        succeed(function({ effects }) {
+            // Guard addon availability
+            if (!addons.has('notifier') || !effects.notifications) {
+                return;
+            }
+
+            addons.notifier.create(effects.notifications);
+        });
+    });
+}, { once: true });
+```
+
+## Escape PHP Values in JavaScript Strings
+
+When injecting PHP values into JavaScript, always use `$escaper->escapeJs()`.
+
+```javascript
+const message = '<?= $escaper->escapeJs(__('Item added to cart')) ?>';
+const productName = '<?= $escaper->escapeJs($magewire->productName) ?>';
+```
+
+Never use `json_encode()` for strings inside JS string literals — it doesn't escape for the HTML/JS context boundary. Use `json_encode()` only for structured data assigned to JS variables.
+
+## Follow the Naming Conventions
+
+| Type | Function name | Registration key |
+|------|--------------|-----------------|
+| Utility | `magewire{Name}Utility()` | `window.MagewireUtilities.register('name', ...)` |
+| Addon | `magewire{Name}Addon()` | `window.MagewireAddons.register('name', ..., reactive)` |
+| Alpine component | `magewire{Name}()` | `Alpine.data('magewire{Name}', ...)` |
+| Directive | — (IIFE) | `Magewire.directive('mage:{name}', ...)` |
+
+- `'use strict'` goes inside the function body, not at module level
+- Utilities return plain objects (no state, no Alpine reactivity)
+- Addons return stateful objects, wrapped in `Alpine.reactive()` when the third arg is `true`
+- Alpine components are thin wrappers that expose addon state via getters
+
+See the `magewire-javascript` skill for the full pattern reference.
+
+## No Inline Styles
+
+Inline `<style>` blocks and `style="..."` attributes require `style-src 'unsafe-inline'`. Move styles to external CSS files. Alpine's `:style` binding is safe — it uses the DOM API, which isn't controlled by CSP `style-src`.

--- a/.agents/skills/magewire-best-practices/references/layout.md
+++ b/.agents/skills/magewire-best-practices/references/layout.md
@@ -1,0 +1,107 @@
+# Layout XML & Block Registration
+
+## Bind the Component via the `magewire` Argument
+
+Magewire can be bound to any block class — the component PHP class goes in the `magewire` data argument. The block class can be `Magewirephp\Magewire\Block\Magewire`, a custom block, or any existing Magento block.
+
+```xml
+<!-- Using the default Magewire block -->
+<block class="Magewirephp\Magewire\Block\Magewire"
+       name="checkout.shipping.method"
+       template="Vendor_Module::shipping-method.phtml">
+    <arguments>
+        <argument name="magewire" xsi:type="object">Vendor\Module\Magewire\ShippingMethod</argument>
+    </arguments>
+</block>
+
+<!-- Binding Magewire to an existing block class -->
+<block class="Vendor\Module\Block\ShippingMethod"
+       name="checkout.shipping.method"
+       template="Vendor_Module::shipping-method.phtml">
+    <arguments>
+        <argument name="magewire" xsi:type="object">Vendor\Module\Magewire\ShippingMethod</argument>
+    </arguments>
+</block>
+
+<!-- Wrong — component class used as block class -->
+<block class="Vendor\Module\Magewire\ShippingMethod"
+       name="checkout.shipping.method"
+       template="Vendor_Module::shipping-method.phtml"/>
+```
+
+## Pass Configuration via Layout Arguments
+
+Use layout XML arguments to configure a component without hardcoding values. Arguments are passed to `mount()` as the `$params` array.
+
+```xml
+<block name="product.reviews"
+       template="Vendor_Module::reviews.phtml">
+    <arguments>
+        <argument name="magewire" xsi:type="object">Vendor\Module\Magewire\Reviews</argument>
+        <argument name="product_id" xsi:type="number">0</argument>
+        <argument name="page_size" xsi:type="number">10</argument>
+        <argument name="sort_order" xsi:type="string">created_at</argument>
+    </arguments>
+</block>
+```
+
+```php
+public function mount(int $productId, int $pageSize = 5, string $sortOrder = 'created_at'): void
+{
+    $this->productId = $productId;
+    $this->pageSize = $pageSize;
+    $this->reviews = $this->loadReviews($sortOrder);
+}
+```
+
+## Use Descriptive Block Names
+
+Block names should be `snake_case` with dots as namespace separators, following Magento's convention. Names must be unique across the entire layout.
+
+```xml
+<!-- Correct -->
+<block name="checkout.shipping.address.form" .../>
+<block name="customer.account.wishlist" .../>
+
+<!-- Wrong -->
+<block name="shippingAddressForm" .../>
+<block name="my-wishlist-block" .../>
+```
+
+## Register in the Right Layout Handle
+
+Place component blocks in the layout handle where they're actually needed — not in `default.xml` unless the component appears on every page.
+
+```xml
+<!-- Correct — only on checkout page -->
+<!-- File: Vendor_Module/view/frontend/layout/checkout_index_index.xml -->
+<referenceContainer name="content">
+    <block class="Magewirephp\Magewire\Block\Magewire" name="checkout.cart.summary" .../>
+</referenceContainer>
+
+<!-- Avoid — in default.xml when only needed on one page -->
+<!-- File: Vendor_Module/view/frontend/layout/default.xml -->
+<referenceContainer name="content">
+    <block class="Magewirephp\Magewire\Block\Magewire" name="checkout.cart.summary" .../>
+</referenceContainer>
+```
+
+## Extend Magewire Layout Containers for JS
+
+When adding JavaScript that integrates with Magewire's lifecycle, use the appropriate named container. Don't create ad-hoc script blocks in `head` or `before.body.end`.
+
+```xml
+<!-- Correct — add a custom Magewire utility -->
+<referenceContainer name="magewire.utilities">
+    <block name="my.custom.utility"
+           template="Vendor_Module::js/magewire/utilities/my-utility.phtml"/>
+</referenceContainer>
+
+<!-- Correct — add a custom directive -->
+<referenceContainer name="magewire.directives">
+    <block name="my.custom.directive"
+           template="Vendor_Module::js/magewire/directives/my-directive.phtml"/>
+</referenceContainer>
+```
+
+See the `magewire-architecture` skill for the full container reference.

--- a/.agents/skills/magewire-best-practices/references/lifecycle.md
+++ b/.agents/skills/magewire-best-practices/references/lifecycle.md
@@ -1,0 +1,121 @@
+# Lifecycle Hooks
+
+## Choose the Right Hook
+
+| Hook | When | Use for |
+|------|------|---------|
+| `mount($params)` | Initial render only | Loading data, setting defaults from layout XML arguments |
+| `boot()` | Every request, before hydrate | Authorization checks, setting up request-scoped state |
+| `booted()` | Every request, after hydrate | Logic that needs the component fully hydrated |
+| `hydrate()` | Subsequent requests only | Restoring non-serializable state (e.g., re-fetching a service) |
+| `updating($prop, $value)` | Before any property change | Validation, access control on property writes |
+| `updated($prop, $value)` | After any property change | Side effects, cascading updates |
+| `rendering($view, $data)` | Before template render | Injecting extra template data |
+| `rendered($view, $html)` | After template render | Post-processing HTML |
+| `dehydrate()` | Before snapshot serialization | Cleanup, adding effects |
+| `exception($e, $stop)` | On exception | Custom error handling, user-facing messages |
+
+## Use `mount()` for One-Time Setup
+
+`mount()` receives parameters passed from layout XML and only runs on the initial render — not on subsequent AJAX requests.
+
+```php
+public function mount(int $categoryId, string $sortOrder = 'position'): void
+{
+    $this->categoryId = $categoryId;
+    $this->sortOrder = $sortOrder;
+    $this->products = $this->loadProducts();
+}
+```
+
+Layout XML passes arguments via the block's `<arguments>`:
+
+```xml
+<block class="Magewirephp\Magewire\Block\Magewire"
+       name="product.listing"
+       template="Vendor_Module::product-listing.phtml">
+    <arguments>
+        <argument name="data" xsi:type="array">
+            <item name="magewire" xsi:type="string">Vendor\Module\Magewire\ProductListing</item>
+        </argument>
+        <argument name="category_id" xsi:type="number">42</argument>
+        <argument name="sort_order" xsi:type="string">price</argument>
+    </arguments>
+</block>
+```
+
+## Use `boot()` for Authorization
+
+`boot()` runs on every request before any data processing. Use it for access control.
+
+```php
+public function boot(): void
+{
+    if (!$this->customerSession->isLoggedIn()) {
+        $this->skipRender();
+        $this->redirect('/customer/account/login');
+    }
+}
+```
+
+## Prefer Property-Specific Hooks Over Generic Ones
+
+When you only care about one property changing, use the property-specific variant. It's clearer and avoids conditional branching.
+
+```php
+// Correct — targeted hook
+public function updatedCountry(string $country): void
+{
+    $this->regions = $this->regionSource->getRegions($country);
+    $this->region = '';
+}
+
+// Avoid — generic hook with conditional
+public function updated(string $property, mixed $value): void
+{
+    if ($property === 'country') {
+        $this->regions = $this->regionSource->getRegions($value);
+        $this->region = '';
+    }
+}
+```
+
+## Never Call `render()` Manually
+
+The framework manages the render cycle automatically. Calling `$this->render()` directly bypasses lifecycle hooks and can cause inconsistent state.
+
+```php
+// Wrong
+public function refresh(): void
+{
+    $this->items = $this->loadItems();
+    $this->render(); // Don't do this
+}
+
+// Correct — the framework re-renders after any public method call
+public function refresh(): void
+{
+    $this->items = $this->loadItems();
+}
+```
+
+## Keep Hooks Lightweight
+
+Hooks run on every request. Avoid expensive operations in `boot()`, `hydrate()`, or `dehydrate()`. If you need data from an external source, cache it or load it lazily.
+
+```php
+// Correct — conditional loading
+public function hydrate(): void
+{
+    if ($this->needsRefresh) {
+        $this->categories = $this->categorySource->toOptionArray();
+        $this->needsRefresh = false;
+    }
+}
+
+// Avoid — loads on every single request
+public function hydrate(): void
+{
+    $this->categories = $this->categorySource->toOptionArray();
+}
+```

--- a/.agents/skills/magewire-best-practices/references/performance.md
+++ b/.agents/skills/magewire-best-practices/references/performance.md
@@ -1,0 +1,103 @@
+# Performance
+
+## Skip Unnecessary Re-renders
+
+Every public method call triggers a full re-render by default. When a method only updates internal state without visible changes, call `$this->skipRender()`.
+
+```php
+public function trackEvent(string $eventName): void
+{
+    $this->analytics->track($eventName);
+    $this->skipRender(); // No DOM changes needed
+}
+```
+
+## Choose the Right `wire:model` Variant
+
+`wire:model.live` sends an AJAX request on every keystroke. For most inputs, the default `wire:model` (syncs on next action) or `wire:model.blur` (syncs on focus loss) is sufficient.
+
+```html
+<!-- Default — syncs on submit/next action (recommended for most forms) -->
+<input wire:model="email" type="email">
+
+<!-- Blur — validates when user leaves field (good for form validation) -->
+<input wire:model.blur="email" type="email">
+
+<!-- Live with debounce — only when instant feedback is needed -->
+<input wire:model.live.debounce.300ms="searchQuery" type="text">
+
+<!-- Avoid — fires on every keystroke without debounce -->
+<input wire:model.live="searchQuery" type="text">
+```
+
+## Minimize Public Properties
+
+Every public property is serialized into the snapshot on every single request — even if it didn't change. Keep the public property count low.
+
+```php
+// Avoid — large dataset as a public property
+public array $allProducts = []; // 500 items serialized every request
+
+// Better — paginated, minimal data
+public array $products = []; // Only current page
+public int $currentPage = 1;
+public int $totalPages = 1;
+```
+
+If data doesn't need to survive between requests, use a computed property instead of storing it as a public property.
+
+## Use `wire:loading` Instead of Polling
+
+Show feedback during server roundtrips with `wire:loading` directives. Don't implement custom polling loops or JavaScript spinners.
+
+```html
+<button wire:click="save" wire:loading.attr="disabled">
+    <span wire:loading.remove wire:target="save">Save Order</span>
+    <span wire:loading wire:target="save">Processing...</span>
+</button>
+```
+
+## Lazy Boot Mode for Rarely-Used Features
+
+If you're creating a Feature that only triggers in specific scenarios, register it with `boot_mode: 10` (LAZY) so it doesn't boot on every request.
+
+```xml
+<item name="my_feature" xsi:type="array">
+    <item name="type" xsi:type="string">Vendor\Module\Features\SupportMyFeature</item>
+    <item name="sort_order" xsi:type="number">5050</item>
+    <item name="boot_mode" xsi:type="number">10</item>
+</item>
+```
+
+## Avoid Heavy Operations in Lifecycle Hooks
+
+`boot()`, `hydrate()`, and `dehydrate()` run on every request. Don't put database queries, API calls, or complex calculations there without guarding.
+
+```php
+// Wrong — database query on every request
+public function boot(): void
+{
+    $this->categories = $this->categoryRepository->getList()->getItems();
+}
+
+// Correct — load once in mount, cache in property
+public function mount(): void
+{
+    $this->categories = $this->loadCategories();
+}
+```
+
+## Keep Component Nesting Shallow
+
+Each nested Magewire component adds to the serialization and rendering cost. Avoid deeply nested component trees — prefer flat compositions with event-based communication.
+
+```xml
+<!-- Prefer: flat sibling components communicating via events -->
+<referenceContainer name="checkout.content">
+    <block ... name="checkout.shipping.address" .../>
+    <block ... name="checkout.shipping.method" .../>
+    <block ... name="checkout.payment" .../>
+</referenceContainer>
+
+<!-- Avoid: deeply nested component hierarchies -->
+```

--- a/.agents/skills/magewire-best-practices/references/properties.md
+++ b/.agents/skills/magewire-best-practices/references/properties.md
@@ -1,0 +1,126 @@
+# Properties & State
+
+## Keep Properties Serializable
+
+Public properties are serialized into the snapshot on every request. Only use types that the framework can serialize: scalars (`string`, `int`, `float`, `bool`), `array`, `null`, and types with registered synthesizers (`DataObject`, PHP enums, `stdClass`).
+
+```php
+// Correct — serializable types
+public string $email = '';
+public array $addresses = [];
+public ?int $selectedId = null;
+
+// Wrong — Magento model is not serializable without a custom synthesizer
+public ?ProductInterface $product = null;
+```
+
+If you need data from a Magento model, extract the relevant fields into scalar properties or an array.
+
+```php
+// Correct — extract what you need
+public function mount(int $productId): void
+{
+    $product = $this->productRepository->getById($productId);
+    $this->productName = $product->getName();
+    $this->productPrice = (float) $product->getPrice();
+    $this->productSku = $product->getSku();
+}
+```
+
+## Use `wire:model` Variants Intentionally
+
+Each `wire:model` variant triggers different request behavior:
+
+| Variant | Behavior | Use when |
+|---------|----------|----------|
+| `wire:model` | Syncs on form submit or next action | Default for most inputs |
+| `wire:model.live` | Syncs on every keystroke/change | Real-time search, character counters |
+| `wire:model.blur` | Syncs when input loses focus | Validation on field exit |
+| `wire:model.live.debounce.300ms` | Debounced live sync | Search with rate limiting |
+
+Default to `wire:model` unless you have a specific reason for live updates. Every `.live` binding generates an AJAX request.
+
+## Use `fill()` for Bulk Assignment
+
+When setting multiple properties at once from an array or DataObject, use `fill()` instead of individual assignments.
+
+```php
+// Correct
+public function loadAddress(int $addressId): void
+{
+    $address = $this->addressRepository->getById($addressId);
+    $this->fill([
+        'street' => $address->getStreet(),
+        'city' => $address->getCity(),
+        'postcode' => $address->getPostcode(),
+    ]);
+}
+
+// Verbose alternative
+public function loadAddress(int $addressId): void
+{
+    $address = $this->addressRepository->getById($addressId);
+    $this->street = $address->getStreet();
+    $this->city = $address->getCity();
+    $this->postcode = $address->getPostcode();
+}
+```
+
+Both work, but `fill()` is cleaner for 3+ properties and triggers the updating/updated hooks correctly.
+
+## Use `reset()` and `resetExcept()` to Restore State
+
+When you need to clear a form or restore defaults, use the built-in reset methods instead of manually assigning each property.
+
+```php
+// Correct — reset specific properties
+public function clearForm(): void
+{
+    $this->reset('email', 'name', 'message');
+}
+
+// Correct — reset everything except the category filter
+public function clearFilters(): void
+{
+    $this->resetExcept('categoryId');
+}
+
+// Correct — get value and reset in one call
+public function consumeMessage(): string
+{
+    return $this->pull('pendingMessage');
+}
+```
+
+## Use Dot Notation for Nested Properties
+
+Magewire supports dot notation for accessing and binding nested array properties.
+
+```html
+<input wire:model="address.street" type="text">
+<input wire:model="address.city" type="text">
+```
+
+```php
+public array $address = [
+    'street' => '',
+    'city' => '',
+    'postcode' => '',
+];
+```
+
+Property-specific lifecycle hooks use StudlyCase for dot notation: `updatingAddressCity($value)` corresponds to `address.city` (dots are replaced with underscores, then the whole string is converted to StudlyCase).
+
+## Never Store Sensitive Data in Public Properties
+
+Public properties are serialized into the HTML as a JSON snapshot visible in the page source. Never store passwords, API keys, tokens, or session identifiers as public properties.
+
+```php
+// Wrong — password visible in page source
+public string $password = '';
+
+// Wrong — API key exposed to client
+public string $apiKey = '';
+```
+
+If a form collects sensitive input, process it immediately in the action method and don't store it as a property, or use a non-public property that won't be part of the snapshot.

--- a/.agents/skills/magewire-best-practices/references/security.md
+++ b/.agents/skills/magewire-best-practices/references/security.md
@@ -1,0 +1,117 @@
+# Security
+
+## CSRF Protection Is Automatic
+
+Magewire uses Magento's FormKey for CSRF protection. Every AJAX request to `magewire/update` includes the form key automatically. You don't need to add tokens manually — but don't disable or bypass FormKey validation in Magento's configuration.
+
+## Snapshot Checksums Prevent Tampering
+
+Every component snapshot includes an HMAC checksum of the `data` and `memo` fields. The server validates this checksum before processing any update. Never bypass or weaken checksum validation — it's the primary defense against state manipulation.
+
+## Public Methods Are Frontend-Callable
+
+Any `public` method on a component can be invoked from the browser via `wire:click`, `wire:submit`, or JavaScript. Treat every public method as an API endpoint.
+
+```php
+// Wrong — admin-level action exposed without authorization
+public function deleteAllProducts(): void
+{
+    $this->productRepository->deleteAll();
+}
+
+// Correct — check authorization before executing
+public function deleteProduct(int $productId): void
+{
+    if (!$this->authorizationService->isAllowed('Vendor_Module::delete_product')) {
+        $this->magewireNotifications()->make(__('Not authorized'))->asError();
+        return;
+    }
+
+    $this->productRepository->deleteById($productId);
+}
+```
+
+## Public Properties Are Visible to the Client
+
+The snapshot is embedded in the HTML as a JSON object. Every public property's value is visible in the page source. Never store secrets, internal IDs that shouldn't be exposed, or PII that the user shouldn't see.
+
+```php
+// Wrong
+public string $adminSecret = '';
+public string $internalApiKey = '';
+public string $hashedPassword = '';
+
+// Correct — use private properties or fetch server-side only
+private string $adminSecret;
+
+public function processWithSecret(): void
+{
+    // Fetch the secret server-side, never expose it
+    $secret = $this->config->getValue('vendor/module/api_key');
+    $this->apiClient->call($secret, $this->publicInput);
+}
+```
+
+## Escape Output in Templates
+
+Use Magento's `$escaper` for every context. See `references/templates.md` for the full pattern.
+
+| Context | Escaper | Example |
+|---------|---------|---------|
+| HTML text | `escapeHtml()` | `<?= $escaper->escapeHtml($magewire->name) ?>` |
+| HTML attribute | `escapeHtmlAttr()` | `class="<?= $escaper->escapeHtmlAttr($val) ?>"` |
+| URL | `escapeUrl()` | `href="<?= $escaper->escapeUrl($magewire->link) ?>"` |
+| JavaScript | `escapeJs()` | `'<?= $escaper->escapeJs($magewire->text) ?>'` |
+
+## Rate Limiting
+
+The `SupportMagewireRateLimiting` feature provides configurable rate limiting for Magewire update requests. It is configured via Magento's admin system configuration and DI — not via PHP attributes on component methods. Enable and configure it through admin settings to prevent abuse of update endpoints.
+
+## Validate Input in Action Methods
+
+Public properties can be set to any value from the frontend. Always validate before using them in business logic — especially before database writes or external API calls.
+
+```php
+public function updateQuantity(int $itemId, int $quantity): void
+{
+    // Validate boundaries
+    if ($quantity < 1 || $quantity > 99) {
+        $this->magewireNotifications()->make(__('Invalid quantity'))->asError();
+        return;
+    }
+
+    // Verify the item belongs to the current user
+    $item = $this->cartRepository->getItem($itemId);
+    if ($item->getCustomerId() !== $this->customerSession->getCustomerId()) {
+        $this->magewireNotifications()->make(__('Not authorized'))->asError();
+        return;
+    }
+
+    $item->setQty($quantity);
+    $this->cartRepository->save($item);
+}
+```
+
+## Don't Trust Method Parameters from the Frontend
+
+Method parameters passed via `wire:click="delete(123)"` come from the HTML — a user can modify them in the browser. Always verify ownership and authorization server-side.
+
+```php
+// Wrong — trusts the ID from the frontend
+public function delete(int $addressId): void
+{
+    $this->addressRepository->deleteById($addressId);
+}
+
+// Correct — verifies ownership
+public function delete(int $addressId): void
+{
+    $address = $this->addressRepository->getById($addressId);
+
+    if ((int) $address->getCustomerId() !== (int) $this->customerSession->getCustomerId()) {
+        return;
+    }
+
+    $this->addressRepository->deleteById($addressId);
+}
+```

--- a/.agents/skills/magewire-best-practices/references/style.md
+++ b/.agents/skills/magewire-best-practices/references/style.md
@@ -1,0 +1,136 @@
+# Conventions & Style
+
+## Naming Conventions
+
+| What | Convention | Good | Bad |
+|------|-----------|------|-----|
+| Component class | PascalCase, singular | `ShippingAddress` | `shipping_address`, `Addresses` |
+| Component namespace | `Vendor\Module\Magewire\` | `Vendor\Module\Magewire\Cart` | `Vendor\Module\Block\Cart` |
+| Public property | camelCase, typed with default | `public string $firstName = ''` | `public $first_name` |
+| Public method | camelCase, verb-first | `addToCart()`, `loadItems()` | `cart_add()`, `Items()` |
+| Event name | kebab-case | `cart-updated` | `cartUpdated`, `CART_UPDATED` |
+| Block name (layout XML) | snake_case with dots | `checkout.shipping.address` | `shippingAddress`, `checkout-shipping` |
+| Template file | kebab-case `.phtml` | `shipping-address.phtml` | `ShippingAddress.phtml` |
+| Feature class | `Support` + scope prefix + name | `SupportMagewireLoaders` | `LoaderFeature`, `MyFeature` |
+| Directive name | `mage:` prefix, kebab-case | `mage:throttle` | `magewire-throttle` |
+| JS utility | `magewire{Name}Utility()` | `magewireStrUtility()` | `strUtility()` |
+| JS addon | `magewire{Name}Addon()` | `magewireNotifierAddon()` | `notifierAddon()` |
+| Alpine component | `magewire{Name}()` | `magewireNotifier()` | `notifierComponent()` |
+
+## Component Class Organization
+
+Place component classes in the `Magewire` subdirectory of your module — not in `Block`, `Model`, or `Controller`.
+
+```
+Vendor/Module/
+├── Magewire/
+│   ├── ShippingAddress.php      ← Component
+│   ├── ShippingMethod.php       ← Component
+│   └── Cart/
+│       ├── Summary.php          ← Grouped component
+│       └── Items.php            ← Grouped component
+├── Block/                       ← Magento blocks (not Magewire components)
+├── Model/                       ← Business models
+└── etc/
+```
+
+## One Component Per File
+
+Each component class gets its own file, named after the class.
+
+## Template Files Match Purpose
+
+Name template files after what they render, not after the component class. Use kebab-case.
+
+```
+Vendor/Module/view/frontend/templates/
+├── shipping-address.phtml       ← Good
+├── shipping-method.phtml
+├── cart/
+│   ├── summary.phtml
+│   └── items.phtml
+```
+
+## PHP Code Style
+
+Follow PSR-12 with Magento conventions:
+
+- `declare(strict_types=1)` at the top of every PHP file
+- Type declarations on all method parameters and return types
+- `readonly` on constructor-promoted properties that don't change
+- `private` by default, `protected` when subclasses need access, `public` only for component API
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\Module\Magewire;
+
+use Magewirephp\Magewire\Component;
+
+class ShippingAddress extends Component
+{
+    public string $street = '';
+    public string $city = '';
+    public string $postcode = '';
+
+    public function __construct(
+        private readonly AddressRepositoryInterface $addressRepository
+    ) {}
+
+    public function mount(int $addressId = 0): void
+    {
+        if ($addressId > 0) {
+            $this->loadAddress($addressId);
+        }
+    }
+
+    public function save(): void
+    {
+        $this->addressRepository->save($this->toAddressData());
+        $this->magewireNotifications()->make(__('Address saved'))->asSuccess();
+    }
+
+    private function loadAddress(int $id): void
+    {
+        $address = $this->addressRepository->getById($id);
+        $this->fill([
+            'street' => $address->getStreet(),
+            'city' => $address->getCity(),
+            'postcode' => $address->getPostcode(),
+        ]);
+    }
+
+    private function toAddressData(): array
+    {
+        return [
+            'street' => $this->street,
+            'city' => $this->city,
+            'postcode' => $this->postcode,
+        ];
+    }
+}
+```
+
+## Keep Logic Out of Templates
+
+Templates render state — they don't compute it. If you find `foreach` loops with calculations, `if` chains with business rules, or service calls in PHTML, move that logic to the component class.
+
+## No HTML in PHP Classes
+
+Component methods return data, not markup. Rendering is the template's job.
+
+```php
+// Wrong
+public function getStatusBadge(): string
+{
+    return '<span class="badge badge-' . $this->status . '">' . $this->status . '</span>';
+}
+
+// Correct — return data, let the template render
+public function getStatusProperty(): string
+{
+    return $this->order->getStatus();
+}
+```

--- a/.agents/skills/magewire-best-practices/references/synthesizers.md
+++ b/.agents/skills/magewire-best-practices/references/synthesizers.md
@@ -1,0 +1,134 @@
+# Serialization & Synthesizers
+
+## Built-in Synthesizers
+
+Magewire includes synthesizers for common types:
+
+| Type | Synthesizer | Location |
+|------|------------|----------|
+| `array` | `ArraySynth` | `dist/` (ported from Livewire) |
+| `stdClass` | `StdClassSynth` | `dist/` (ported from Livewire) |
+| PHP enums | `EnumSynth` | `dist/` (ported from Livewire) |
+| `float` | `FloatSynth` | `dist/` (ported from Livewire) |
+| `int` | `IntSynth` | `dist/` (ported from Livewire) |
+| `DataObject` | `DataObjectSynth` | `lib/Magewire/` (Magento-specific) |
+
+If your property type isn't in this list, you need a custom synthesizer or should restructure your data into supported types.
+
+## Prefer Scalar Properties Over Custom Synthesizers
+
+Before writing a synthesizer, ask whether you can restructure the data into scalars or arrays. Custom synthesizers add maintenance burden and can be fragile across Magewire upgrades.
+
+```php
+// Preferred — extract what you need into scalars
+public string $customerName = '';
+public string $customerEmail = '';
+public int $customerId = 0;
+
+// Only if the full object is genuinely needed at the serialization boundary
+public ?DataObject $customerData = null; // Handled by DataObjectSynth
+```
+
+## Writing a Custom Synthesizer
+
+Implement three methods: `match()`, `dehydrate()`, `hydrate()`.
+
+```php
+namespace Vendor\Module\Synthesizers;
+
+use Magewirephp\Magewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+
+class MoneySynth extends Synth
+{
+    public static string $key = 'money';
+
+    /**
+     * Return true if this synthesizer handles the given type.
+     */
+    public static function match(mixed $target): bool
+    {
+        return $target instanceof \Vendor\Module\ValueObject\Money;
+    }
+
+    /**
+     * Convert the object to a JSON-safe representation.
+     * Returns [$data, $metadata].
+     */
+    public function dehydrate(mixed $target, callable $dehydrateChild): array
+    {
+        return [
+            [
+                'amount' => $target->getAmount(),
+                'currency' => $target->getCurrency(),
+            ],
+            [] // metadata (empty if not needed)
+        ];
+    }
+
+    /**
+     * Reconstruct the object from dehydrated data.
+     */
+    public function hydrate(mixed $data, array $metadata, callable $hydrateChild): mixed
+    {
+        return new \Vendor\Module\ValueObject\Money(
+            $data['amount'],
+            $data['currency']
+        );
+    }
+}
+```
+
+## Register in Area-Scoped DI
+
+Synthesizers are registered on the `HandleComponents` mechanism with a sort order — first matching synthesizer wins. Follow the area-scoped DI rule: `etc/frontend/di.xml` or `etc/adminhtml/di.xml`, never global `etc/di.xml`. See `references/di.md` for the XML format.
+
+## Ensure Round-Trip Fidelity
+
+The fundamental contract: `hydrate(dehydrate($value))` must produce a value equivalent to the original. Test this explicitly.
+
+```php
+$original = new Money(1999, 'USD');
+$synth = new MoneySynth();
+
+[$data, $meta] = $synth->dehydrate($original, fn($k, $v) => $v);
+$restored = $synth->hydrate($data, $meta, fn($k, $v) => $v);
+
+assert($restored->getAmount() === $original->getAmount());
+assert($restored->getCurrency() === $original->getCurrency());
+```
+
+## `dehydrate()` Must Return JSON-Safe Data
+
+The dehydrated data is JSON-encoded into the snapshot. Only return scalars, arrays of scalars, and nested arrays. No objects, resources, closures, or circular references.
+
+```php
+// Wrong — object in dehydrated data
+public function dehydrate(mixed $target, callable $dehydrateChild): array
+{
+    return [$target, []]; // Object isn't JSON-safe
+}
+
+// Correct — extract to scalars
+public function dehydrate(mixed $target, callable $dehydrateChild): array
+{
+    return [
+        ['amount' => $target->getAmount(), 'currency' => $target->getCurrency()],
+        []
+    ];
+}
+```
+
+## Avoid Storing Magento Models Directly
+
+Magento models (`Product`, `Category`, `Customer`, etc.) are complex objects with service dependencies, resource models, and event managers. Even with a synthesizer, serializing them is fragile and expensive. Extract the data you need into scalar properties.
+
+```php
+// Wrong — storing a full product model
+public ?ProductInterface $product = null;
+
+// Correct — extract only what's needed
+public int $productId = 0;
+public string $productName = '';
+public float $productPrice = 0.0;
+public string $productImage = '';
+```

--- a/.agents/skills/magewire-best-practices/references/templates.md
+++ b/.agents/skills/magewire-best-practices/references/templates.md
@@ -1,0 +1,118 @@
+# Templates & Views
+
+## Single Root Element
+
+Every Magewire component template must have exactly one root HTML element. Magewire attaches its `wire:snapshot` and `wire:effects` attributes to this element and uses it as the morph target.
+
+```html
+<!-- Correct -->
+<div>
+    <h2><?= $escaper->escapeHtml($magewire->title) ?></h2>
+    <p><?= $escaper->escapeHtml($magewire->description) ?></p>
+</div>
+
+<!-- Wrong — multiple root elements -->
+<h2><?= $escaper->escapeHtml($magewire->title) ?></h2>
+<p><?= $escaper->escapeHtml($magewire->description) ?></p>
+```
+
+## Escape All Dynamic Output
+
+Magento provides purpose-specific escapers. Use the right one for the context — never output raw user data.
+
+```php
+<!-- Text content -->
+<?= $escaper->escapeHtml($magewire->name) ?>
+
+<!-- URL attribute -->
+<a href="<?= $escaper->escapeUrl($magewire->profileUrl) ?>">
+
+<!-- HTML attribute value -->
+<div class="<?= $escaper->escapeHtmlAttr($magewire->cssClass) ?>">
+
+<!-- Inside JavaScript -->
+<div x-data="{ name: '<?= $escaper->escapeJs($magewire->name) ?>' }">
+
+<!-- Translation -->
+<?= $escaper->escapeHtml(__('Add to Cart')) ?>
+```
+
+Never use `htmlspecialchars()` or `strip_tags()` directly — Magento's `$escaper` handles encoding correctly for each context.
+
+## Keep Templates Thin
+
+Templates should render state, not compute it. Move logic into the component class — methods, computed properties, or lifecycle hooks.
+
+```php
+<!-- Wrong — business logic in template -->
+<?php
+$subtotal = 0;
+foreach ($magewire->items as $item) {
+    $subtotal += $item['price'] * $item['qty'];
+}
+?>
+<span><?= $escaper->escapeHtml(number_format($subtotal, 2)) ?></span>
+
+<!-- Correct — computed property in component -->
+<span><?= $escaper->escapeHtml(number_format($magewire->subtotal, 2)) ?></span>
+```
+
+## Access Component State via `$magewire`
+
+The `$magewire` variable is the component instance. Access properties and call methods on it directly.
+
+```html
+<div>
+    <!-- Property access -->
+    <span><?= $escaper->escapeHtml($magewire->count) ?></span>
+
+    <!-- Computed property -->
+    <span><?= $escaper->escapeHtml($magewire->fullName) ?></span>
+
+    <!-- Conditional rendering -->
+    <?php if ($magewire->isActive): ?>
+        <span>Active</span>
+    <?php endif ?>
+</div>
+```
+
+## Use `$block` for Magento Integration
+
+The `$block` variable is the Magento block instance (`Magewirephp\Magewire\Block\Magewire`). Use it for Magento-specific functionality like child blocks, URLs, and view file paths.
+
+```html
+<!-- Render a nested Magento block -->
+<?= $block->getChildHtml('sidebar') ?>
+
+<!-- Get a static asset URL -->
+<img src="<?= $escaper->escapeUrl($block->getViewFileUrl('images/logo.svg')) ?>">
+
+<!-- Get a store URL -->
+<a href="<?= $escaper->escapeUrl($block->getUrl('customer/account')) ?>">
+```
+
+## Use `wire:key` for Dynamic Lists
+
+When rendering lists that can change order or length, add `wire:key` to help the DOM differ track elements correctly.
+
+```html
+<?php foreach ($magewire->items as $item): ?>
+    <div wire:key="item-<?= $escaper->escapeHtmlAttr($item['id']) ?>">
+        <?= $escaper->escapeHtml($item['name']) ?>
+    </div>
+<?php endforeach ?>
+```
+
+## Loading States for User Feedback
+
+Use `wire:loading` directives to show feedback during server roundtrips — don't implement custom polling or spinners.
+
+```html
+<button wire:click="save" wire:loading.attr="disabled">
+    <span wire:loading.remove>Save</span>
+    <span wire:loading>Saving...</span>
+</button>
+
+<!-- Target specific actions -->
+<div wire:loading wire:target="search">Searching...</div>
+```

--- a/.agents/skills/magewire-javascript/SKILL.md
+++ b/.agents/skills/magewire-javascript/SKILL.md
@@ -1,0 +1,506 @@
+---
+name: magewire-javascript
+description: "Use this skill whenever writing JavaScript for Magento 2 themes that are not RequireJS-driven. Covers CSP-compatible components, PHP-driven reactivity via Magewire, AlpineJS integration with Magewire lifecycle hooks, and reusable multi-theme JavaScript structure. Always apply as the default JS convention for non-RequireJS Magento 2 themes. Do NOT use for RequireJS-driven themes or server-side PHP Magewire component logic."
+allowed-tools: ["Bash", "Read", "Write"]
+---
+
+# Magento 2 CSP-Compatible JavaScript (Magewire & AlpineJS)
+
+This skill covers writing modern, CSP-compatible JavaScript for Magento 2 themes that are not RequireJS-driven.
+It follows a Magewire-first convention that embraces PHP-driven reactivity, clean separation of concerns,
+and deep AlpineJS integration — enabling components that are reusable across multiple themes while remaining
+fully compliant with Magento 2's Content Security Policy requirements.
+
+---
+
+## Directory structure
+
+**Key principle:** All templates containing JavaScript must live inside a `js/` subdirectory within the view template tree, organized by technology. This separation is critical — it makes clear which templates contain JS (and therefore need CSP handling) vs. which are pure HTML/PHP. The view area determines
+the root, and must always be chosen deliberately:
+
+| Area | Path | When to use |
+|---|---|---|
+| `base` | `src/view/base/templates/js/` | Available in both frontend and adminhtml |
+| `frontend` | `src/view/frontend/templates/js/` | Frontend themes only |
+| `adminhtml` | `src/view/adminhtml/templates/js/` | Magento admin only |
+
+Inside `js/`, files are grouped by JavaScript framework and then by category. The same structure is mirrored
+across all view areas. Feature PHTMLs live **outside** `js/`, in a sibling `magewire-features/` directory.
+
+```
+templates/
+├── js/                         # Script templates (wrapped in CSP fragments)
+│   ├── alpinejs/               # AlpineJS-specific code
+│   │   ├── magewire.phtml      # Global — sits directly at the framework root
+│   │   ├── components/         # Alpine components (x-data) — standalone only
+│   │   │   └── magewire-notifier.phtml
+│   │   └── directives/         # Custom Alpine directives (x-on, x-bind wrappers)
+│   └── magewire/               # Magewire-specific code
+│       ├── global.phtml        # Global — sits directly at the framework root
+│       ├── addons/             # Reusable plain-JS APIs — standalone only
+│       │   └── notifier.phtml
+│       ├── directives/         # Custom Magewire directives (mage:*)
+│       │   ├── throttle.phtml
+│       │   └── notify.phtml
+│       └── utilities/          # Single-responsibility helper functions
+│           ├── dom.phtml
+│           ├── loader.phtml
+│           └── str.phtml
+└── magewire-features/          # All PHTMLs belonging to a Support* feature
+    └── support-magewire-loaders/
+        ├── support-magewire-loaders.phtml   # Primary bridge script
+        ├── addon.phtml                      # Optional feature-owned addon
+        └── component.phtml                  # Optional feature-owned Alpine component
+```
+
+**Rules:**
+- Global code that applies to an entire framework goes directly at the framework root (e.g., `alpinejs/magewire.phtml`).
+- Category-specific code goes in its named subfolder.
+- **Feature PHTMLs live in `magewire-features/{feature-name}/`** — a sibling of `js/`, not nested inside it. This applies to core features and theme compatibility features alike.
+- Each feature gets its own subfolder named after the feature class, with a same-named primary PHTML inside.
+- `addons/` and `alpinejs/components/` are for **standalone** components only — things reusable outside Magewire. If an addon or Alpine component belongs exclusively to a `Support*` feature, it lives inside that feature's folder under `magewire-features/` instead.
+- The directory structure under `templates/` must be identical across all view areas.
+
+---
+
+## PHP boilerplate
+
+Every PHTML file starts with the same PHP header. The fragment utility handles CSP nonce/hash injection
+automatically — never write a raw `<script>` tag.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\ViewModel\Magewire as MagewireViewModel;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var MagewireViewModel $magewireViewModel */
+
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+
+/** @internal Do not modify to ensure Magewire continues to function correctly. */
+?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    // ... your JS here
+</script>
+<?php $script->end() ?>
+```
+
+- `$escaper` is always imported even when not used directly in this file, so subblocks can rely on it.
+- The `@internal` docblock signals that this file is not intended for theme override.
+- Never omit `$script->end()`. The fragment mechanism is only complete when `end()` is called.
+
+**PHP values in JS strings** — always escape through `$escaper->escapeJs()`:
+
+```php
+'<?= $escaper->escapeJs(__('Too many requests! Please wait.')) ?>'
+```
+
+**PHP comments inside `<script>` blocks** — use PHP comment syntax, not JS comments:
+
+```php
+<?php /* This is an internal note that won't appear in the output. */ ?>
+```
+
+---
+
+## Utilities
+
+Utilities are single-responsibility helper functions with no dependencies on Magewire or Alpine.
+They are plain JavaScript returned from a named function and registered on `window.MagewireUtilities`.
+
+**Pattern:**
+
+```javascript
+function magewire{Name}Utility() {
+    'use strict';
+
+    return {
+        methodName: function(arg) {
+            // ...
+        }
+    }
+}
+
+<?php /* Register as Magewire utility. */ ?>
+document.addEventListener('alpine:init', () => window.MagewireUtilities.register('name', magewire{Name}Utility), { once: true });
+```
+
+**Rules:**
+- The function name is `magewire` + PascalCase name + `Utility`.
+- `'use strict'` goes inside the function body, not outside.
+- The function returns a plain object — no class, no prototype.
+- Method names are short and clean. Prefer `parseText` over `parseInputTextString`.
+- Registration uses `alpine:init` with `{ once: true }` to prevent double registration.
+- The registration key (`'name'`) is the camelCase utility name, accessed later as `window.MagewireUtilities.name`.
+- Utilities do not take Alpine reactive state — they are pure functions.
+
+**Access from other files:**
+
+```javascript
+const text = window.MagewireUtilities.loader.parseText(value);
+```
+
+---
+
+## Addons
+
+Addons are reusable, framework-agnostic JavaScript APIs. They are the primary place for stateful logic,
+event hooks, and async operations. Themes can consume an addon without knowing anything about Magewire internals.
+
+**Pattern:**
+
+```javascript
+function magewire{Name}Addon() {
+    'use strict';
+
+    return {
+        // Public state
+        items: [],
+
+        // Lifecycle hooks (arrays of callbacks)
+        hooks: {
+            onCreate: [],
+            onTerminate: []
+        },
+
+        // Defaults
+        defaults: {
+            item: { state: 'idle', duration: null }
+        },
+
+        // API methods — short, clean names
+        create: async function(data, options = {}) { /* ... */ },
+        get:    function(id) { /* ... */ },
+        remove: async function(id) { /* ... */ },
+
+        // Internal trigger helper
+        trigger: async function(hook, args = {}) { /* ... */ }
+    };
+}
+
+<?php /* Register as Magewire addon. */ ?>
+window.MagewireAddons.register('name', magewire{Name}Addon, true);
+```
+
+**Rules:**
+- The function name is `magewire` + PascalCase name + `Addon`.
+- `'use strict'` inside the function body.
+- The third argument `true` to `register()` makes the result `Alpine.reactive()`. Use `true` whenever
+  the addon holds state that needs to drive the DOM.
+- Registration happens immediately (not inside an event listener). The `MagewireResource` class queues
+  reactive registrations if Alpine is not yet ready and processes them on `alpine:init`.
+- Addons can reference `window.Magewire` at call time, but must not depend on it being present at
+  registration time.
+- The public API should be flat and named clearly. Hide implementation details as closures or `const`
+  variables inside the factory function, not as underscore-prefixed properties.
+
+**Access from other files:**
+
+```javascript
+if (window.MagewireAddons.has('name')) {
+    window.MagewireAddons.name.create(data);
+}
+```
+
+---
+
+## Alpine components
+
+Alpine components are thin wrappers that expose an addon's state and a limited set of methods to the HTML template.
+They exist solely to bridge the addon API with Alpine's `x-data` system in a CSP-compatible way.
+
+Magewire ships `magewire.csp.min.js`, which is an unmodified direct copy of Livewire's JavaScript bundle.
+Livewire's bundle includes the Alpine CSP build (`@alpinejs/csp`), which removes the dependency on `eval`
+and `new Function` for expression evaluation. Most JavaScript expressions still work in HTML attributes.
+The key difference is scope: only the component's own data properties and methods are in scope for HTML
+attribute expressions. Closure variables declared inside the factory function (e.g.,
+`const addon = window.MagewireAddons.poll`) are not accessible from HTML attributes — they must be exposed
+as named methods on the returned object.
+
+**Pattern:**
+
+```javascript
+function magewire{Name}() {
+    'use strict';
+
+    const addon = window.MagewireAddons.name;
+
+    return {
+        // Expose reactive addon state as a getter
+        get items() {
+            return addon.items;
+        },
+
+        <?php /* START: Only add those methods that should become CSP compatible. */ ?>
+        remove: function() {
+            addon.remove(this.item.id);
+        },
+        <?php /* END */ ?>
+
+        // bindings: x-bind objects for elements that need multiple directives at once
+        bindings: {
+            item: {
+                root: function() {
+                    return {
+                        'x-on:click'() { addon.remove(this.item.id); },
+                        'x-bind:class'() { return ['item', `item--${this.item.type}`]; }
+                    }
+                }
+            }
+        }
+    }
+}
+
+<?php /* Register as Alpine component. */ ?>
+document.addEventListener('alpine:init', () => Alpine.data('magewire{Name}', magewire{Name}), { once: true });
+```
+
+**Rules:**
+- The function name is `magewire` + PascalCase component name (no suffix).
+- Expose addon state via `get` accessors so Alpine reactivity flows through.
+- The `bindings` object holds `x-bind` definitions for complex element interactions.
+  This lets templates use `x-bind="bindings.item.root()"` rather than inline Alpine expressions.
+- Only methods that are called directly from HTML attributes belong inside the component.
+  Pure internal helpers stay inside the addon.
+- The PHP comment markers `START` / `END` delimit methods that exist to expose closure-variable logic
+  (addon calls, utility calls) to HTML attributes. Without these wrappers, `@click="addon.stop()"` would
+  fail because `addon` is a closure variable, not a component data property.
+- Registration uses `alpine:init` with `{ once: true }`.
+- If the component also exposes `Alpine.bind()` bindings, register a separate function:
+
+```javascript
+function magewire{Name}Bindings() {
+    return {
+        'x-bind:class'() { return 'my-component'; }
+    };
+}
+
+document.addEventListener('alpine:init', () => Alpine.bind('magewire{Name}Bindings', magewire{Name}Bindings), { once: true });
+```
+
+**What Livewire's bundled Alpine CSP build forbids in HTML attribute expressions:**
+
+| Forbidden | Why | Alternative |
+|---|---|---|
+| `` x-text="`Hello ${name}`" `` | Template literals | `x-text="'Hello ' + name"` |
+| `@click="() => remove()"` | Arrow functions | `@click="remove()"` |
+| `x-for="[k, v] in entries"` | Destructuring | Pre-compute `{k, v}` objects in data |
+| `x-bind="{ ...defaults }"` | Spread operators | Return explicit object from method |
+| `x-text="Object.keys(obj).length"` | Global functions | Expose via component method |
+| `x-text="JSON.stringify(val)"` | Global functions | Expose via component method |
+| `@click="user.name = 'John'"` | Nested property assignment | Expose via component method |
+| `x-html="..."` | Blocked entirely | Restructure as text or component |
+
+Everything else — ternaries, object literals, comparisons, arithmetic, string concatenation, negation,
+simple assignments, `&&`/`||` — works fine in HTML attribute expressions.
+
+Global functions not in scope include: `Object.entries`, `Object.keys`, `Object.values`, `Math.*`,
+`JSON.*`, `parseInt`, `parseFloat`, `console.*`, `document.*`, `window.*`.
+
+Pre-compute any data that would require global functions in templates. Store the result directly on
+the data object:
+
+```javascript
+// In the factory function or when updating state:
+propEntries: Object.keys(data).map(k => ({ k, v: data[k] }))
+
+// In the template — simple iteration, no globals needed:
+// x-for="p in propEntries" → x-text="p.k" / x-text="p.v"
+```
+
+---
+
+## Directives
+
+Directives are custom Alpine or Magewire directives registered via `Magewire.directive()`.
+They add declarative HTML attributes that control element behavior.
+
+**Pattern:**
+
+```javascript
+(() => {
+    'use strict';
+
+    document.addEventListener('magewire:initialized', event => {
+        Magewire.directive('mage:{name}', ({ el, directive, component, cleanup }) => {
+            const action = event => {
+                // handle the event
+            };
+
+            el.addEventListener('click', action, { capture: true });
+
+            cleanup(() => el.removeEventListener('click', action));
+        });
+    });
+})();
+```
+
+**Rules:**
+- Wrap in an IIFE `(() => { ... })()` — directives are self-contained and export nothing.
+- `'use strict'` at the top of the IIFE.
+- Listen on `magewire:initialized` (not `magewire:init` — directives require the full runtime to be ready).
+- Magewire directive names use the `mage:` prefix: `mage:throttle`, `mage:notify`. In HTML attributes, the full attribute becomes `wire:mage:notify` (Livewire's `wire:` prefix + the `mage:` directive name).
+- Always call `cleanup()` to deregister event listeners and prevent memory leaks.
+- Directive modifiers and expressions are read from the `directive` parameter:
+  `directive.modifiers` (array of strings), `directive.expression` (string).
+
+---
+
+## Standalone components
+
+A standalone component is a self-contained UI piece that can be used independently of Magewire. It consists
+of three layers:
+
+1. **Addon** (`js/magewire/addons/`) — the stateful JS API. Framework-agnostic, can run without Magewire.
+2. **Alpine component** (`js/alpinejs/components/`) — thin wrapper exposing addon state and a minimal set of
+   methods to HTML templates.
+3. **UI template** (`magewire/ui-components/`) — the rendered HTML that consumes the Alpine component via
+   `x-data`. Child templates go in a same-named subdirectory next to the main template.
+
+```
+src/view/base/templates/
+├── js/
+│   ├── alpinejs/components/magewire-{name}.phtml   ← Alpine component
+│   └── magewire/addons/{name}.phtml                ← Addon
+└── magewire/
+    └── ui-components/
+        ├── {name}.phtml                            ← UI template (x-data="magewire{Name}")
+        └── {name}/
+            └── {child}.phtml                       ← Child templates
+```
+
+The UI template is a plain Magento PHTML block registered in the `magewire.ui-components` layout container.
+It uses `x-data="magewire{Name}"` and optionally `x-bind="magewire{Name}Bindings"`.
+
+**When to use standalone vs. feature-owned:**
+
+- Use the standalone pattern when the functionality should be usable independently — e.g. the notifier
+  addon can be driven by anything (a custom JS call, a Magewire effect, a theme) without any Magewire
+  component being on the page. `addons/` and `alpinejs/components/` are **reserved for this pattern only**.
+- When an addon, Alpine component, or HTML template belongs exclusively to a `Support*` feature, it is
+  **feature-owned** and must live inside that feature's folder, not in the global `addons/` or
+  `alpinejs/components/` directories. See the Features section below.
+
+A Magewire PHP feature can still *integrate* with a standalone component — it just pushes an effect that
+the standalone component's JS layer reacts to. The two are independent; the feature is the bridge.
+
+---
+
+## Features
+
+A feature's folder is the home for **all** JS and HTML that exclusively belongs to a `Support*` PHP
+feature class. This includes the lifecycle bridge script, but also any addon, Alpine component, or HTML
+template that only makes sense in the context of that feature.
+
+**File placement:** all PHTMLs for a feature (bridge script, addon, Alpine component, HTML template) live together in a single folder:
+
+```
+view/{area}/templates/magewire-features/support-{name}/
+```
+
+This location applies to **both** core framework features (in the Magewire module) and theme compatibility features (in theme modules like Hyvä).
+
+The primary JS file is named after the feature class (`support-magewire-loaders.phtml`). Additional
+sub-PHPTMLs within the same folder (e.g. `addon.phtml`, `component.phtml`) are fine when the feature
+owns an addon or Alpine component.
+
+**Layout registration:**
+- The `magewire.features` container always has **one block per feature**. Any additional PHPTMLs (addon,
+  Alpine component) are registered as **child blocks** of the primary feature block, not as siblings.
+  The primary PHTML renders them in the correct order via `$block->getChildHtml('addon')` etc.
+- HTML PHPTMLs → a single block in `magewire.after` (not `magewire.ui-components`, which is for
+  standalone components only).
+
+```xml
+<block name="magewire.features.support-{name}"
+       template="Magewirephp_Magewire::magewire-features/support-{name}/support-{name}.phtml"
+>
+    <block name="magewire.features.support-{name}.addon"
+           as="addon"
+           template="Magewirephp_Magewire::magewire-features/support-{name}/addon.phtml"
+    />
+    <block name="magewire.features.support-{name}.component"
+           as="component"
+           template="Magewirephp_Magewire::magewire-features/support-{name}/component.phtml"
+    />
+</block>
+```
+
+Keep each PHTML file as small and focused as possible — Magento allows individual PHTML files to be overwritten by themes, so smaller files give theme developers more granular control. The parent block template renders children via `$block->getChildHtml()`:
+
+**Bridge pattern (the primary feature file):**
+
+```javascript
+document.addEventListener('magewire:init', function() {
+    const addons = window.MagewireAddons;
+
+    Magewire.hook('commit', function({ succeed }) {
+        succeed(function({ effects }) {
+            if (!addons.has('name') || !effects.myEffect) {
+                return;
+            }
+
+            addons.name.update(effects.myEffect);
+        });
+    });
+}, { once: true });
+```
+
+**Rules:**
+- Feature scripts listen on `magewire:init` with `{ once: true }`.
+- Always guard addon access with `addons.has('name')` — addons are optional.
+- Read `window.MagewireAddons` and `window.MagewireUtilities` into local `const` at the top for clarity.
+- No IIFE needed — the `magewire:init` listener already scopes the code.
+- Feature-owned addons and Alpine components follow the exact same patterns as standalone ones — the
+  only difference is their location on disk and which layout container their block uses.
+
+---
+
+## Event timing reference
+
+| Event | When it fires | Use for |
+|---|---|---|
+| `alpine:init` | Alpine starts, before DOM walk | `Alpine.data()`, `Alpine.store()`, `Alpine.bind()`, utility/addon registration |
+| `magewire:init` | Magewire runtime ready, Alpine initializing | Magewire hooks (`commit`, `request`), feature initialization |
+| `magewire:initialized` | Full initialization complete | `Magewire.directive()` registration |
+
+Always use `{ once: true }` on `addEventListener` calls for registration events to prevent
+double-registration on navigations or re-hydrations.
+
+---
+
+## Layout XML registration
+
+Every PHTML must have a corresponding block in the layout XML for the matching view area.
+
+- `base` PHPTMLs → `src/view/base/layout/default.xml`
+- `frontend` PHPTMLs → `src/view/frontend/layout/default.xml`
+- `adminhtml` PHPTMLs → `src/view/adminhtml/layout/default.xml`
+
+The available layout elements for JS registration, in render order. Elements marked **(block)** have parent templates that render children via `$block->getChildHtml()`. Elements marked **(container)** are pure injection points.
+
+| Name | Type | Purpose |
+|------|------|---------|
+| `magewire.alpinejs` | container | Global Alpine code (stores, plugins) |
+| `magewire.alpinejs.components` | container | `Alpine.data` component registrations |
+| `magewire.utilities` | block | Utility registrations — add children as blocks inside |
+| `magewire.utilities.after` | container | Custom utilities after core ones |
+| `magewire.addons` | block | Addon registrations — add children as blocks inside |
+| `magewire.addons.after` | container | Custom addons after core ones |
+| `magewire.alpinejs.directives` | container | Custom Alpine directives (inside `magewire.before`) |
+| `magewire.ui-components` | container | Alpine UI components (inside `magewire.before`) |
+| `magewire.directives` | block | Magewire directive registrations (`mage:*`) — add children as blocks |
+| `magewire.features` | block | Feature JS — add children as blocks |
+| `magewire.after` | container | Everything else (HTML blocks, debug tools) |
+
+The `view_model` argument is injected automatically by `SupportMagewireViewModel`. Do not add it manually
+in layout XML blocks.
+

--- a/.agents/skills/magewire-javascript/references/examples.md
+++ b/.agents/skills/magewire-javascript/references/examples.md
@@ -1,0 +1,439 @@
+# Examples
+
+All examples use the same domain — a simple **clipboard** utility, a **poll** addon that drives an Alpine
+component, a **copy** directive, and a **sync** feature — so you can see how each piece relates to the others.
+
+---
+
+## Utility
+
+A utility returns a plain object of pure helper functions. No state, no dependencies.
+
+**`src/view/base/templates/js/magewire/utilities/clipboard.phtml`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\ViewModel\Magewire as MagewireViewModel;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var MagewireViewModel $magewireViewModel */
+
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    function magewireClipboardUtility() {
+        'use strict';
+
+        return {
+            copy: async function(text) {
+                if (! navigator.clipboard) {
+                    return false;
+                }
+
+                try {
+                    await navigator.clipboard.writeText(text);
+                    return true;
+                } catch {
+                    return false;
+                }
+            },
+
+            read: async function() {
+                if (! navigator.clipboard) {
+                    return null;
+                }
+
+                try {
+                    return await navigator.clipboard.readText();
+                } catch {
+                    return null;
+                }
+            }
+        }
+    }
+
+    <?php /* Register as Magewire utility. */ ?>
+    document.addEventListener('alpine:init', () => window.MagewireUtilities.register('clipboard', magewireClipboardUtility), { once: true });
+</script>
+<?php $script->end() ?>
+```
+
+**Layout block** in `src/view/base/layout/default.xml`, inside `magewire.utilities`:
+
+```xml
+<block name="magewire.utilities.clipboard"
+       template="Magewirephp_Magewire::js/magewire/utilities/clipboard.phtml"
+/>
+```
+
+---
+
+## Addon
+
+An addon is a stateful, framework-agnostic API. It is Alpine-reactive when the third argument to
+`register()` is `true`, allowing its state to drive the DOM directly.
+
+**`src/view/base/templates/js/magewire/addons/poll.phtml`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\ViewModel\Magewire as MagewireViewModel;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var MagewireViewModel $magewireViewModel */
+
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    function magewirePollAddon() {
+        'use strict';
+
+        return {
+            active:   false,
+            interval: null,
+            count:    0,
+
+            start: function(ms = 5000) {
+                if (this.active) {
+                    return;
+                }
+
+                this.active   = true;
+                this.interval = setInterval(() => {
+                    this.count++;
+                    this.tick();
+                }, ms);
+            },
+
+            stop: function() {
+                clearInterval(this.interval);
+                this.active   = false;
+                this.interval = null;
+            },
+
+            tick: function() {
+                if (window.Magewire) {
+                    Magewire.triggerAsync('addons.poll.tick', { count: this.count });
+                }
+            },
+
+            reset: function() {
+                this.stop();
+                this.count = 0;
+            }
+        };
+    }
+
+    <?php /* Register as Magewire addon. */ ?>
+    window.MagewireAddons.register('poll', magewirePollAddon, true);
+</script>
+<?php $script->end() ?>
+```
+
+**Layout block** in `src/view/base/layout/default.xml`, inside `magewire.addons`:
+
+```xml
+<block name="magewire.addons.poll"
+       template="Magewirephp_Magewire::js/magewire/addons/poll.phtml"
+/>
+```
+
+---
+
+## Alpine component
+
+An Alpine component is a thin wrapper that exposes addon state and a limited set of methods to HTML templates.
+All logic lives in the addon. The component only provides what the template needs.
+
+Magewire ships `magewire.csp.min.js`, an unmodified copy of Livewire's JavaScript bundle, which includes
+the Alpine CSP build. HTML attribute expressions can only access properties and methods defined on the
+component's returned data object. Closure variables like `const poll = window.MagewireAddons.poll` are
+not in scope from HTML — they must be wrapped in component methods. That is the sole reason for the
+`START/END` comment markers.
+
+**`src/view/base/templates/js/alpinejs/components/magewire-poll.phtml`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\ViewModel\Magewire as MagewireViewModel;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var MagewireViewModel $magewireViewModel */
+
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    function magewirePoll() {
+        'use strict';
+
+        const poll = window.MagewireAddons.poll;
+
+        return {
+            get active() { return poll.active; },
+            get count()  { return poll.count; },
+
+            <?php /* START: Only add those methods that should become CSP compatible. */ ?>
+            start: function() {
+                poll.start();
+            },
+            stop: function() {
+                poll.stop();
+            },
+            reset: function() {
+                poll.reset();
+            },
+            <?php /* END */ ?>
+
+            bindings: {
+                toggle: function() {
+                    return {
+                        'x-bind:aria-pressed'() {
+                            return poll.active;
+                        },
+                        'x-on:click'() {
+                            poll.active ? poll.stop() : poll.start();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    <?php /* Register as Alpine component. */ ?>
+    document.addEventListener('alpine:init', () => Alpine.data('magewirePoll', magewirePoll), { once: true });
+</script>
+<?php $script->end() ?>
+```
+
+**Usage in a theme template:**
+
+```html
+<div x-data="magewirePoll">
+    <span x-text="count"></span>
+    <button x-bind="bindings.toggle()">Toggle</button>
+    <button @click="reset()">Reset</button>
+</div>
+```
+
+**Layout block** in `src/view/base/layout/default.xml`, inside `magewire.alpinejs.components`:
+
+```xml
+<block name="magewire.alpinejs.components.magewire-poll"
+       template="Magewirephp_Magewire::js/alpinejs/components/magewire-poll.phtml"
+/>
+```
+
+---
+
+## Directive
+
+A directive adds a declarative HTML attribute. It is self-contained and exports nothing.
+
+**`src/view/base/templates/js/magewire/directives/copy.phtml`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\ViewModel\Magewire as MagewireViewModel;
+
+/** @var Template $block */
+/** @var MagewireViewModel $magewireViewModel */
+
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    (() => {
+        'use strict';
+
+        document.addEventListener('magewire:initialized', event => {
+            Magewire.directive('mage:copy', ({ el, directive, cleanup }) => {
+                const source = directive.expression
+                    ? document.querySelector(directive.expression)
+                    : el;
+
+                const action = async () => {
+                    const text = source?.textContent?.trim() ?? '';
+
+                    if (window.MagewireUtilities && window.MagewireUtilities.has('clipboard')) {
+                        await window.MagewireUtilities.clipboard.copy(text);
+                    }
+                };
+
+                el.addEventListener('click', action);
+
+                cleanup(() => el.removeEventListener('click', action));
+            });
+        });
+    })();
+</script>
+<?php $script->end() ?>
+```
+
+**Usage:**
+
+```html
+<!-- Copies own text content -->
+<button mage:copy>Copy me</button>
+
+<!-- Copies text from a target element -->
+<code id="snippet">npm install magewire</code>
+<button mage:copy="#snippet">Copy command</button>
+```
+
+**Layout block** in `src/view/base/layout/default.xml`, inside `magewire.directives`:
+
+```xml
+<block name="magewire.directives.copy"
+       template="Magewirephp_Magewire::js/magewire/directives/copy.phtml"
+/>
+```
+
+---
+
+## Feature
+
+A feature bridges a Magewire PHP Feature's effects to an addon or utility. It reads effects pushed by PHP
+and calls the appropriate addon methods.
+
+The PHP side pushes a custom effect in `dehydrate()`:
+
+```php
+public function dehydrate(ComponentContext $context): void
+{
+    $context->pushEffect('poll', ['reset' => true]);
+}
+```
+
+**`src/view/base/templates/magewire-features/support-magewire-poll/support-magewire-poll.phtml`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\ViewModel\Magewire as MagewireViewModel;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var MagewireViewModel $magewireViewModel */
+
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    document.addEventListener('magewire:init', event => {
+        const addons = window.MagewireAddons;
+
+        Magewire.hook('commit', ({ succeed }) => {
+            succeed(({ effects }) => {
+                if (! addons.has('poll')) {
+                    return;
+                }
+
+                const data = effects.poll ?? {};
+
+                if (data.reset === true) {
+                    addons.poll.reset();
+                }
+            });
+        });
+    });
+</script>
+<?php $script->end() ?>
+```
+
+**Layout block** in `src/view/base/layout/default.xml`, inside `magewire.features`:
+
+```xml
+<block name="magewire.features.support-magewire-poll"
+       template="Magewirephp_Magewire::magewire-features/support-magewire-poll/support-magewire-poll.phtml"
+/>
+```
+
+---
+
+## Frontend-only component
+
+When a component uses frontend-specific APIs (e.g., Hyva's `hyva.getFormKey()`), it goes in `frontend/` instead of `base/`.
+The structure under `js/` is identical — only the view area changes.
+
+**`src/view/frontend/templates/js/alpinejs/components/magewire-form.phtml`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\ViewModel\Magewire as MagewireViewModel;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var MagewireViewModel $magewireViewModel */
+
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    function magewireForm() {
+        'use strict';
+
+        return {
+            bindings: {
+                root: function() {
+                    return {
+                        'x-bind:data-csrf'() {
+                            return hyva.getFormKey();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    document.addEventListener('alpine:init', () => Alpine.data('magewireForm', magewireForm), { once: true });
+</script>
+<?php $script->end() ?>
+```
+
+**Layout block** in `src/view/frontend/layout/default.xml`:
+
+```xml
+<block name="magewire.alpinejs.components.magewire-form"
+       template="Magewirephp_Magewire::js/alpinejs/components/magewire-form.phtml"
+/>
+```

--- a/.agents/skills/magewire-javascript/references/reference.md
+++ b/.agents/skills/magewire-javascript/references/reference.md
@@ -1,0 +1,372 @@
+# Reference
+
+---
+
+## Naming conventions
+
+| Type | Function name | Example |
+|---|---|---|
+| Utility | `magewire{Name}Utility` | `magewireClipboardUtility` |
+| Addon | `magewire{Name}Addon` | `magewirePollAddon` |
+| Alpine component | `magewire{Name}` | `magewirePoll` |
+| Alpine bindings | `magewire{Name}Bindings` | `magewirePollBindings` |
+| Directive | — (IIFE, no export) | — |
+| Feature | — (event listener, no export) | — |
+
+Registration keys are the camelCase name without prefix or suffix: `'clipboard'`, `'poll'`, `'notifier'`.
+
+---
+
+## Registration calls
+
+```javascript
+// Utility — waits for alpine:init
+document.addEventListener('alpine:init', () => window.MagewireUtilities.register('name', factoryFn), { once: true });
+
+// Addon — immediate; MagewireResource queues reactive items if Alpine is not yet ready
+window.MagewireAddons.register('name', factoryFn, true);   // true = Alpine.reactive
+window.MagewireAddons.register('name', factoryFn, false);  // false = plain object
+
+// Alpine component
+document.addEventListener('alpine:init', () => Alpine.data('magewire{Name}', factoryFn), { once: true });
+
+// Alpine bindings (optional companion)
+document.addEventListener('alpine:init', () => Alpine.bind('magewire{Name}Bindings', bindingsFn), { once: true });
+
+// Alpine store
+document.addEventListener('alpine:init', () => Alpine.store('name', { ... }));
+
+// Directive
+document.addEventListener('magewire:initialized', event => Magewire.directive('mage:name', handler));
+```
+
+---
+
+## Event timing
+
+| Event | Fires when | Register here |
+|---|---|---|
+| `alpine:init` | Alpine starts, before DOM walk | `Alpine.data`, `Alpine.store`, `Alpine.bind`, utilities, addons (if not immediate) |
+| `magewire:init` | Magewire runtime ready | `Magewire.hook('commit')`, `Magewire.hook('request')`, feature init |
+| `magewire:initialized` | Full init complete | `Magewire.directive()` |
+
+Always add `{ once: true }` to registration listeners.
+
+---
+
+## PHP boilerplate
+
+**Minimal (no PHP values in JS):**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\ViewModel\Magewire as MagewireViewModel;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var MagewireViewModel $magewireViewModel */
+
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+?>
+<?php $script = $magewireFragment->make()->script()->start() ?>
+<script>
+    // ...
+</script>
+<?php $script->end() ?>
+```
+
+**With PHP enum values:**
+
+```php
+use Magewirephp\Magewire\Model\Magewire\Notifier\NotificationStateEnum;
+
+$state = NotificationStateEnum::IDLE->getState(); // used inside escapeJs()
+```
+
+```javascript
+const state = '<?= $escaper->escapeJs(NotificationStateEnum::IDLE->getState()) ?>';
+const levels = JSON.parse('<?= json_encode(NotificationStateEnum::cases()) ?>');
+```
+
+**PHP comment inside `<script>`:**
+
+```php
+<?php /* This comment does not appear in rendered output. */ ?>
+```
+
+---
+
+## Alpine CSP expression rules
+
+`magewire.csp.min.js` is an unmodified direct copy of Livewire's JavaScript bundle. Livewire's bundle
+includes the Alpine CSP build (`@alpinejs/csp`), which removes the dependency on `eval` and `new Function`.
+Only a minimal subset of expressions is safe in HTML attributes — when in doubt, move logic into a component method.
+
+**Allowed in HTML attribute expressions:**
+
+| Pattern | Example |
+|---|---|
+| Property access | `x-text="item.name"` |
+| Method reference (no parens) | `@click="remove"`, `x-show="isOpen"` |
+| Simple property assignment | `@click="open = false"` |
+| Object literal | `:class="{'active': isOpen}"` |
+| `x-for` iteration | `x-for="item in items"` |
+| `x-bind` plain object property | `x-bind="bindings.root"` |
+
+**Forbidden in HTML attribute expressions:**
+
+| Pattern | Example | Alternative |
+|---|---|---|
+| Method calls with parens | `@click="remove()"`, `x-show="isOpen()"` | `@click="remove"`, `x-show="isOpen"` |
+| Method args in HTML | `@click="selectItem(123)"` | `@click="selectItem" data-item-id="123"` (use `this.$el.dataset`) |
+| Loop var as method arg | `@click="expand(entry)"` | `@click="expand"` — access via `this.entry` inside method |
+| Template literals | `` x-text="`Hi ${name}`" `` | Use a component method |
+| Arrow functions | `@click="() => remove()"` | `@click="remove"` |
+| Destructuring | `x-for="[k, v] in entries"` | Pre-compute `{k, v}` objects |
+| Spread operators | `x-bind="{ ...obj }"` | Return explicit object from method |
+| Function call in `x-bind` | `x-bind="bindings.root()"` | `x-bind="bindings.root"` (plain object property) |
+| Comparison / equality | `x-show="count > 0"`, `x-show="a === b"` | `x-show="hasEntries"` (method) |
+| Ternary | `x-text="a ? 'x' : 'y'"` | Use a component method |
+| Arithmetic / string concat | `x-text="count + 1"` | Use a component method |
+| Negation / logical operators | `x-show="!loading"`, `x-show="a && b"` | Use a component method |
+| Global functions | `x-text="Object.keys(o).length"` | Expose count via component method |
+| Nested property assignment | `@click="user.name = 'val'"` | Expose via component method |
+| `x-model` | `x-model="value"` | `:value="value"` + `@input="setValue"` |
+| Range `x-for` | `x-for="i in 10"` | Pre-compute an array |
+| `x-html` | Any | Restructure as text content |
+
+Globals not in scope: `Object.*`, `Math.*`, `JSON.*`, `parseInt`, `parseFloat`, `console.*`,
+`document.*`, `window.*`.
+
+**Loop variable scope:** variables from `x-for="entry in entries"` are accessible inside methods
+as `this.entry`. Never pass them as arguments from HTML:
+
+```javascript
+// ✗ fails — method args in HTML not supported
+// @click="toggleExpand(entry)"
+
+// ✓ works — access loop var via this inside the method
+toggleExpand: function() { this.entry.expanded = !this.entry.expanded; }
+// @click="toggleExpand"
+```
+
+**Closure variable scope:** closure variables inside the factory function are not accessible from HTML.
+Expose them as component methods:
+
+```javascript
+// ✗ fails — addon is a closure variable, not a component property
+// @click="addon.stop()"
+
+// ✓ works — stop is a property of the returned object
+stop: function() { addon.stop(); }
+// @click="stop"
+```
+
+Pre-compute anything that would require global functions in templates:
+
+```javascript
+// In factory function or when updating state:
+propEntries: Object.keys(data).map(k => ({ k, v: data[k] }))
+
+// In template — no globals needed:
+// x-for="p in propEntries" → x-text="p.k" / x-text="p.v"
+```
+
+---
+
+## CSP stylesheet rules
+
+| Pattern | Safe | Notes |
+|---|---|---|
+| `<link rel="stylesheet" href="...">` | Yes | Same-origin covered by `style-src 'self'` |
+| External `.css` file via `getViewFileUrl()` | Yes | Standard Magento static file resolution |
+| Alpine `:style` binding | Yes | Set via JS DOM API, not blocked by `style-src` |
+| `<style>` block | **No** | Requires `style-src 'unsafe-inline'` |
+| `style="..."` HTML attribute | **No** | Requires `style-src 'unsafe-inline'` |
+
+**Loading an external stylesheet from PHTML:**
+
+```php
+<link rel="stylesheet" href="<?= $escaper->escapeUrl($block->getViewFileUrl('Magewirephp_Magewire::css/my-file.css')) ?>">
+```
+
+CSS files live at `src/view/{area}/web/css/`.
+
+---
+
+## Script CSP
+
+The `$magewireFragment->make()->script()->start()` / `$script->end()` pattern handles all cases automatically:
+
+| Page cache state | CSP method used |
+|---|---|
+| FPC disabled or layout not cacheable | `nonce="..."` attribute on `<script>` |
+| FPC enabled and layout cacheable | SHA hash registered with `DynamicCspCollector` |
+
+Never write a raw `<script>` tag in Magewire PHTML files.
+
+---
+
+## Addon access patterns
+
+```javascript
+// Check before use (addons are optional)
+if (window.MagewireAddons.has('name')) {
+    window.MagewireAddons.name.method();
+}
+
+// Direct access when presence is guaranteed (e.g., inside the component wrapping it)
+const addon = window.MagewireAddons.name;
+
+// Utility access
+const result = window.MagewireUtilities.name.method(arg);
+```
+
+---
+
+## Directory structure
+
+```
+src/view/
+├── base/
+│   ├── layout/default.xml
+│   ├── templates/
+│   │   ├── js/                                     ← JS-only PHTML files
+│   │   │   ├── alpinejs/
+│   │   │   │   ├── {global}.phtml                  ← sits at framework root
+│   │   │   │   ├── components/                     ← standalone Alpine components only
+│   │   │   │   │   └── magewire-{name}.phtml
+│   │   │   │   └── directives/                     ← reserved for custom Alpine directives
+│   │   │   └── magewire/
+│   │   │       ├── {global}.phtml                  ← sits at framework root
+│   │   │       ├── addons/                         ← standalone addons only
+│   │   │       │   └── {name}.phtml
+│   │   │       ├── directives/
+│   │   │       │   └── {name}.phtml
+│   │   │       ├── features/                       ← all JS owned by a Support* feature
+│   │   │       │   └── support-{name}/
+│   │   │       │       ├── support-{name}.phtml    ← primary bridge file
+│   │   │       │       ├── addon.phtml             ← feature-owned addon (if any)
+│   │   │       │       └── component.phtml         ← feature-owned Alpine component (if any)
+│   │   │       └── utilities/
+│   │   │           └── {name}.phtml
+│   │   └── magewire/                               ← Non-JS PHTML templates
+│   │       ├── ui-components/                      ← standalone UI templates only
+│   │       │   ├── {name}.phtml
+│   │       │   └── {name}/
+│   │       │       └── {child}.phtml
+│   │       └── features/                           ← HTML templates owned by a Support* feature
+│   │           └── support-{name}/
+│   │               └── {name}.phtml
+│   └── web/css/
+│       └── {name}.css
+├── frontend/
+│   ├── layout/default.xml
+│   └── templates/                  ← same structure as base/templates/
+└── adminhtml/
+    ├── layout/default.xml
+    └── templates/                  ← same structure as base/templates/
+```
+
+---
+
+## Layout container reference
+
+Containers render in this order:
+
+| Container | Content |
+|---|---|
+| `magewire.global.before` | Parent of `magewire.alpinejs.load`, `magewire.alpinejs`, `magewire.alpinejs.components` |
+| `magewire.alpinejs` | Global Alpine code (stores, plugins) — before Magewire's Alpine code |
+| `magewire.alpinejs.components` | `Alpine.data` component registrations |
+| `magewire.utilities` | Utility registrations |
+| `magewire.addons` | Addon registrations |
+| `magewire.global.after` | Custom extensions after the global block |
+| `magewire.before` | Parent of `magewire.alpinejs.directives`, `magewire.ui-components`, `magewire.alpinejs.after` |
+| `magewire.alpinejs.directives` | Custom Alpine directives (inside `magewire.before`) |
+| `magewire.ui-components` | Alpine UI components (inside `magewire.before`) |
+| `magewire.alpinejs.after` | Custom Alpine code after Magewire's code (inside `magewire.before`) |
+| `magewire.before.internal` | Internal state blocks |
+| `magewire.internal` | Core internal scripts — do not override |
+| `magewire.directives` | Magewire directive registrations (`mage:*`) |
+| `magewire.features` | Feature JS |
+| `magewire.after.internal` | Post-internal extensions |
+| `magewire.disabled` | Renders only when Magewire is inactive |
+| `magewire.after` | Everything else (HTML blocks, debug tools) |
+| `magewire.legacy` | V1 backwards compatibility — do not use for new code |
+
+The `view_model` argument on layout blocks is injected automatically by `SupportMagewireViewModel`.
+Do not add it in layout XML.
+
+---
+
+## Per-type checklist
+
+**Utility**
+- [ ] Function named `magewire{Name}Utility`
+- [ ] `'use strict'` inside the function body
+- [ ] Returns a plain object with named methods
+- [ ] Registered via `MagewireUtilities.register()` inside `alpine:init` with `{ once: true }`
+- [ ] Block placed in `magewire.utilities` container
+
+**Addon**
+- [ ] Function named `magewire{Name}Addon`
+- [ ] `'use strict'` inside the function body
+- [ ] Returns a full API object (state + methods)
+- [ ] Registered via `MagewireAddons.register()` immediately (not inside listener)
+- [ ] Third argument `true` if state needs to be Alpine-reactive
+- [ ] Block placed in `magewire.addons` container
+
+**Alpine component**
+- [ ] Function named `magewire{Name}` (no suffix)
+- [ ] `'use strict'` inside the function body
+- [ ] Reads addon via `const addon = window.MagewireAddons.name`
+- [ ] Exposes state via `get` accessors
+- [ ] Only methods called from HTML templates included (CSP comment markers)
+- [ ] Complex element bindings in `bindings` object
+- [ ] Registered via `Alpine.data()` inside `alpine:init` with `{ once: true }`
+- [ ] Block placed in `magewire.alpinejs.components` container
+- [ ] No template literals, arrow functions, destructuring, spread, or global functions in HTML attributes
+- [ ] No operators in HTML attributes (comparisons, ternary, negation, arithmetic) — use methods instead
+- [ ] Methods referenced without parentheses in HTML: `@click="toggle"`, `x-show="isOpen"` (never `toggle()`)
+- [ ] No method arguments passed from HTML — loop variables accessed via `this.varName` inside methods
+- [ ] Closure variables (addon, utility references) exposed as component methods — not called directly from HTML
+
+**Directive**
+- [ ] Wrapped in IIFE `(() => { 'use strict'; ... })()`
+- [ ] Registered inside `magewire:initialized` listener
+- [ ] Name uses `mage:` prefix
+- [ ] All event listeners removed via `cleanup()`
+- [ ] Block placed in `magewire.directives` container
+
+**Feature (JS bridge)**
+- [ ] Listens on `magewire:init` with `{ once: true }`
+- [ ] Reads `window.MagewireAddons` and `window.MagewireUtilities` into local `const`
+- [ ] Guards addon access with `addons.has('name')`
+- [ ] Primary file named after the PHP Feature class, inside the feature's folder
+- [ ] Block placed in `magewire.features` container
+
+**Feature-owned addon / Alpine component**
+- [ ] Lives in `templates/magewire-features/support-{name}/` — NOT in `addons/` or `alpinejs/components/`
+- [ ] Follows same patterns as standalone addon/Alpine component
+- [ ] Registered as **child blocks** of the primary feature block (with `as="addon"`, `as="component"`)
+- [ ] Primary PHTML renders them via `$block->getChildHtml('addon')`, `$block->getChildHtml('component')` — in that order, before the bridge script
+- [ ] Only ONE block for the feature sits directly in `magewire.features` — never sibling blocks
+
+**Feature-owned HTML template**
+- [ ] Lives at `templates/magewire-features/support-{name}/{name}.phtml`
+- [ ] Block placed in `magewire.after` container — NOT `magewire.ui-components`
+
+**Standalone component (UI template)**
+- [ ] Addon registered in `magewire.addons`, Alpine component in `magewire.alpinejs.components`
+- [ ] UI template at `templates/magewire/ui-components/{name}.phtml`
+- [ ] Child templates in `templates/magewire/ui-components/{name}/`
+- [ ] Uses `x-data="magewire{Name}"` (and optionally `x-bind="magewire{Name}Bindings"`)
+- [ ] Block placed in `magewire.ui-components` container
+- [ ] Justified as standalone: the addon is usable without a Magewire component on the page

--- a/.agents/skills/magewire-portman/SKILL.md
+++ b/.agents/skills/magewire-portman/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: magewire-portman
+description: "Reference for Portman — the dev-only CLI tool that ports Livewire PHP into Magewire by downloading upstream source, merging augmentations, transforming namespaces, and writing the result to dist/. Use when syncing Magewire with a new Livewire release, writing augmentation files in portman/Livewire/, running portman build/watch, or understanding the relationship between lib/Livewire, portman/, and dist/."
+---
+
+# Magewire Portman
+
+Portman is a **general-purpose PHP library porting CLI tool** created by Justin van Elst. While its primary use case is porting Livewire into Magewire, it is architecturally framework-agnostic and can be used to port any PHP package between frameworks. Its purpose is to automate the process of pulling upstream PHP source code (from Packagist), transforming it (rename namespaces, rename classes, remove methods), and merging local augmentations.
+
+Portman is a standalone Composer package (`magewirephp/portman`) and is a **dev-only dependency** — Magewire operates fully independently without it. It is only needed when contributing to Magewire or syncing with a new Livewire release.
+
+Nearly everything in Portman is configurable via `portman.config.php`: source directories, output directory, augmentation paths, file glob patterns, ignore rules, namespace/class transformations, method/property removals, file doc blocks, and post-processors.
+
+---
+
+## Why Portman Exists
+
+Magewire's PHP core is a port of Laravel Livewire v3. Rather than forking and diverging, Magewire uses Portman to:
+
+1. Download a specific Livewire release from Packagist
+2. Rename all `Livewire\` namespaces to `Magewirephp\Magewire\`
+3. Rename specific classes (e.g. `LivewireManager` → `MagewireManager`)
+4. Remove Laravel-specific methods that don't apply in Magento
+5. Merge Magewire-specific augmentations (additional methods, properties) into the ported classes
+6. Output the result into `dist/` ready for use
+
+When Livewire ships a new version, Magewire can re-run Portman against the new release to get the update, with only the augmentation files needing manual review.
+
+---
+
+## Commands
+
+```bash
+vendor/bin/portman                  # Show help / list commands
+vendor/bin/portman init             # Generate a default portman.config.php
+vendor/bin/portman download-source  # Download packages from Packagist into cache
+vendor/bin/portman build            # Run the full build (merge + transform → output)
+vendor/bin/portman watch            # Watch source/augmentation dirs and rebuild on save
+```
+
+`watch` requires `chokidar-cli` installed globally or locally via npm:
+
+```bash
+npm install chokidar-cli
+```
+
+---
+
+## Configuration: `portman.config.php`
+
+The config file is a PHP array validated as a typed DTO (via Spatie Laravel-Data).
+
+```php
+<?php
+
+return [
+    'directories' => [
+
+        // Upstream sources to download and transform
+        'source' => [
+            'lib/Livewire' => [
+                'composer' => [
+                    'name'         => 'livewire/livewire',
+                    'version'      => '~3.6.4',     // Composer constraint
+                    'version-lock' => '3.6.4',       // Exact pinned version
+                    'base-path'    => 'src',          // Subfolder within the package
+                ],
+                'glob'   => '**/*.php',              // Which files to process
+                'ignore' => [                         // Ant-style exclusions
+                    'SomeDirectory/**/*',
+                    '!SomeDirectory/KeepThis.php',   // ! negates previous rule
+                ],
+            ],
+        ],
+
+        // Local files that get merged INTO matching source files
+        'augmentation' => [
+            'portman/Livewire',           // In Magewire: portman/Livewire/
+        ],
+
+        // Where the output lands
+        'output' => 'dist',
+    ],
+
+    'transformations' => [
+        'Livewire\\' => [                              // Match a namespace (ends with \\)
+            'rename' => 'Magewirephp\\Magewire\\',    // Rename to
+            'file-doc-block' => '/** ... */',          // Prepend to all files in namespace
+            'children' => [
+                'LivewireManager' => [
+                    'rename' => 'MagewireManager',     // Rename class
+                ],
+                'Features\\SupportRedirects\\HandlesRedirects' => [
+                    'remove-methods' => [              // Drop these methods
+                        'redirectAction',
+                        'redirectRoute',
+                    ],
+                    'remove-properties' => [           // Drop these properties
+                        'laravelSpecificProp',
+                    ],
+                ],
+            ],
+        ],
+    ],
+
+    'post-processors' => [
+        'rector'        => false,    // Run Rector after build
+        'php-cs-fixer'  => false,    // Run PHP-CS-Fixer after build
+    ],
+];
+```
+
+The config file path can be overridden via the `PORTMAN_CONFIG_FILE` environment variable (set in a `.env` file or shell environment). Defaults to `portman.config.php` in the project root.
+
+---
+
+## How the Build Works
+
+### 1. Download Phase (`download-source`)
+
+- Reads each `composer` entry in `directories.source`
+- Downloads the package ZIP from Packagist at the specified version
+- Extracts only the `base-path` subdirectory into a local cache
+- Applies `glob` and `ignore` filters to select files
+
+### 2. Build Phase (`build`)
+
+For each file that matches a source entry, Portman runs:
+
+**a) Parse** — Both the source file and its matching augmentation file (if any) are parsed into ASTs using `nikic/php-parser`.
+
+**b) Merge** — `ClassMerger` collects all methods, properties, and traits from the augmentation class and injects them into the source class AST. Augmentation wins on conflicts.
+
+**c) Transform** — `Renamer` walks the merged AST and applies namespace renames, class renames, method/property removals, and file doc block insertions according to `transformations`.
+
+**d) Output** — The transformed AST is pretty-printed back to PHP and written to `directories.output`.
+
+**Additional files** are copied directly to output without parsing or merging.
+
+### 3. Post-processing (optional)
+
+If enabled, Rector and/or PHP-CS-Fixer are run over the output directory after the build.
+
+---
+
+## Augmentation Files
+
+An augmentation file is a PHP class file placed at the same relative path as the source file it augments, inside the augmentation directory (in Magewire: `portman/Livewire/`).
+
+Example: to add a method to `lib/Livewire/ComponentHook.php`, create:
+
+```
+portman/Livewire/ComponentHook.php
+```
+
+```php
+<?php
+
+namespace Livewire;  // Use the SOURCE namespace, not the output namespace
+
+class ComponentHook
+{
+    // Only the methods/properties you want to add or override
+    public function myMagewireAddition(): void
+    {
+        // This gets merged into the ported ComponentHook class
+    }
+}
+```
+
+Portman merges the augmentation's members into the source class. The output will use the transformed namespace (`Magewirephp\Magewire\`), not `Livewire\`.
+
+---
+
+## Additional Files
+
+Files placed in `directories.additional` are copied verbatim to the output — no parsing, no merging, no namespace transformation. Use these for Magewire-only classes that have no upstream Livewire counterpart and need to land in `dist/` alongside the ported code.
+
+Note: in Magewire's own setup, Magewire-specific core code (`lib/Magewire/`, `lib/MagewireBc/`, etc.) lives in `lib/` as hand-written source and is NOT routed through Portman. Portman only handles the Livewire-derived code.
+
+---
+
+## Ignore Patterns
+
+The `ignore` array uses Ant-style glob patterns (processed by `webmozart/glob`):
+
+```php
+'ignore' => [
+    'Console/**/*',           // Exclude everything in Console/
+    'Testing/**/*',           // Exclude testing utilities
+    '!Testing/Testable.php',  // But keep this one file
+]
+```
+
+Rules are applied in order. A `!` prefix negates (un-ignores) a previous exclusion.
+
+---
+
+## Typical Workflow
+
+**Initial setup:**
+
+```bash
+composer require --dev magewirephp/portman
+vendor/bin/portman init
+# Edit portman.config.php
+vendor/bin/portman download-source
+vendor/bin/portman build
+```
+
+**Syncing with a new Livewire release:**
+
+1. Update `version` / `version-lock` in `portman.config.php`
+2. `vendor/bin/portman download-source` (updates `lib/Livewire/`)
+3. `vendor/bin/portman build`
+4. Review diff in `dist/` — check `portman/Livewire/` augmentation files for conflicts
+
+**Active development (live rebuild):**
+
+```bash
+vendor/bin/portman watch
+# Edit files in portman/Livewire/
+# dist/ is rebuilt automatically on each save
+```
+
+**Adding a new class from upstream:**
+
+- Remove it from `ignore` in `portman.config.php`
+- Run `vendor/bin/portman build`
+
+**Overriding an upstream method:**
+
+- Create a matching file in `portman/Livewire/` with just that method
+- Run `vendor/bin/portman build`
+
+**Adding a Magewire-only class that belongs in `dist/`:**
+
+- Place the file in the `additional` directory (configured in `portman.config.php`)
+- Run `vendor/bin/portman build`
+- It is copied as-is, no transformation applied
+
+---
+
+## Key Files in the Portman Package
+
+| File | Purpose |
+|------|---------|
+| `app/Commands/BuildCommand.php` | Entry point for `build` |
+| `app/Commands/DownloadSource.php` | Entry point for `download-source` |
+| `app/Commands/WatchCommand.php` | Entry point for `watch` |
+| `app/Portman/SourceBuilder.php` | Orchestrates the full build pipeline |
+| `app/Portman/ClassMerger.php` | AST node visitor: merges augmentation into source |
+| `app/Portman/Renamer.php` | AST node visitor: applies namespace/class renames |
+| `app/Portman/TransformerConfiguration.php` | Maps config rules to transformer actions |
+| `app/Portman/Configuration/Data/` | Spatie DTO classes for config validation |
+| `stubs/portman.config.php` | Template config generated by `init` |
+
+---
+
+## Relationship to Magewire's Directory Structure
+
+The directory paths below are the defaults used in Magewire's `portman.config.php`. All paths (source, augmentation, output) are configurable — these are not hardcoded by Portman.
+
+| Directory | Config key | Role | Edit? |
+|-----------|-----------|------|-------|
+| `lib/Livewire/` | `directories.source` | Downloaded upstream source (Portman input cache) | No |
+| `portman/Livewire/` | `directories.augmentation` | Augmentations — what to change in upstream source | Yes |
+| `dist/` | `directories.output` | Portman build output (ported + merged + transformed) | No |
+| `lib/Magewire/` | — | Hand-written Magewire core (not Portman-managed) | Yes |
+| `lib/MagewireBc/` | — | Hand-written backwards compatibility layer | Yes |
+| `lib/Magento/` | — | Hand-written Magento framework integrations | Yes |
+| `src/` | — | Magento module structure (etc/, controllers, layout) | Yes |
+
+**Never edit `dist/` or `lib/Livewire/` directly.** `dist/` is overwritten on every `portman build`. `lib/Livewire/` is overwritten on every `portman download-source`.
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|---------|
+| `dist/` folder missing after `composer install` | Run `../../bin/portman build` from inside the Magewire vendor directory |
+| Augmentation warnings during build | Run `../../bin/portman download-source` first, then rebuild |
+
+Note: commands are run as `../../bin/portman` when working from inside `vendor/magewirephp/magewire/`.

--- a/.agents/skills/magewire-theming/SKILL.md
+++ b/.agents/skills/magewire-theming/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: magewire-theming
+description: "Use when building, extending, or debugging a theme-specific Magewire integration for Magento 2 — creating a new theme compatibility module, overriding Magewire layout containers for a theme, registering theme-scoped Features/observers/directives, wiring Alpine loading order for Hyvä/Luma/Breeze/Backend themes, or packaging theme-specific Tailwind CSS. Trigger phrases include: theme module, compatibility module, theme integration, `themes/Hyva`, `themes/Luma`, Hyvä Magewire integration, adminhtml Magewire theming, theme layout override, per-theme Feature, theme-scoped DI, Tailwind in a Magewire theme. Apply whenever the user mentions anything under `themes/` or asks how to make Magewire work with a specific Magento theme. Distinguish from `magewire-javascript` (which is about writing CSP-safe JS for any theme) — this skill is about the **module plumbing** around a theme."
+requires: magewire, magewire-architecture, magewire-javascript, magewire-best-practices
+license: MIT
+metadata:
+  author: Willem Poortman
+---
+
+# Magewire Theming
+
+How to build and extend **theme compatibility modules** for Magewire — the thin Magento modules that live under `themes/{Theme}/` and wire Magewire into a specific Magento theme (Hyvä, Luma, Breeze, Backend, or a custom one).
+
+## Mental model
+
+Magewire ships in three layers:
+
+1. **Core module** (`src/`) — global controllers, DI, events, layout XML, templates. Theme-agnostic.
+2. **Global view layer** (`src/view/base/` + `src/view/frontend/`) — the layout skeleton every theme inherits. Defines named containers for JS addons, utilities, Alpine components, directives, Features.
+3. **Theme compatibility modules** — each Magento module in its own right. Declares a dependency on `Magewirephp_Magewire` and plugs into the global view layer via layout references, DI, observers, and Features. These live in two places:
+   - **In-tree** at `themes/{Theme}/` inside the main `magewirephp/magewire` package (Hyvä, Luma, Breeze, Backend). Ships with the core package, PSR-4 mapped via the root `composer.json`.
+   - **Standalone** as a separate composer package — the canonical example is `magewirephp/magewire-admin`, which provides full adminhtml integration (admin session validation, admin update endpoint, RequireJS compatibility, head-phase script injection).
+
+A theme module's job is to adapt Magewire to one target theme's conventions: Alpine loading order, template overrides, Tailwind pipeline, and any BC shims that theme needs. **Everything reusable belongs in `src/`. Everything theme-specific belongs in a theme module (in-tree or standalone).**
+
+### Why `magewire-admin` is standalone, not in-tree
+
+Adminhtml needs more than layout wiring — it needs a custom controller with admin session validation, a plugin on Magento's `Page\Config\Renderer` to inject scripts before RequireJS, and a RequireJS module that patches Prototype.js pollution. Because those cross-cut controllers, plugins, and a component resolver, they don't fit the minimal "theme folder" shape. `themes/Backend/` in the main package is only a marker — the real integration lives in `magewire-admin`. When building adminhtml Magewire features, treat `magewire-admin` as the canonical reference, not `themes/Backend/`.
+
+## Consistency first
+
+Before creating anything, read the existing theme module that most resembles your target theme:
+
+- Deep integration example: `themes/Hyva/` (Hyvä Checkout needed full v1→v3 BC)
+- Minimal compat example: `themes/Luma/`, `themes/Breeze/`, `themes/Backend/` (registration + `module.xml` only)
+
+Copy the established naming, sort order, and container wiring. Inconsistency across theme modules is worse than a suboptimal pattern in one.
+
+## When to use which footprint
+
+| Need | Minimum footprint |
+|------|------------------|
+| Mark theme as compatible (no real integration) | `registration.php` + `etc/module.xml` |
+| Load order tweak (e.g., Alpine before Magewire) | + `view/{area}/layout/default_{theme}.xml` |
+| Theme-scoped Feature (lifecycle hook) | + `etc/{area}/di.xml` + `Magewire/Features/*.php` |
+| Bridge to theme build pipeline (Tailwind, Hyvä config) | + `Observer/*.php` + `etc/{area}/events.xml` |
+| Theme-specific Alpine loaders, directives, BC shims | + `view/{area}/templates/**/*.phtml` |
+| Theme-specific CSS | + `view/frontend/tailwind/*` |
+| Full adminhtml integration (custom update endpoint, admin session, RequireJS fix, head-phase script injection) | Standalone package like `magewire-admin` with `Controller/*`, `Plugin/*`, `Magewire/Mechanisms/*`, `etc/adminhtml/{di,routes}.xml` |
+
+Add only what the theme needs — empty modules are better than speculative scaffolding.
+
+## Quick reference
+
+### 1. Module structure → `references/module-structure.md`
+
+- Module name convention: `Magewirephp_MagewireCompatibilityWith{Theme}`
+- PSR-4 namespace: `Magewirephp\MagewireCompatibilityWith{Theme}\`
+- PSR-4 path is added to the root `composer.json` of the `magewirephp/magewire` package, not to a per-theme composer file
+- `module.xml` must declare `<sequence><module name="Magewirephp_Magewire"/></sequence>` so Magewire boots first
+- If the theme module depends on another Magento module (e.g. `Hyva_Theme`), add that to the sequence too
+
+### 2. Layout containers → `references/layout-containers.md`
+
+The global `default.xml` defines these public extension points. Prefer `<referenceContainer>` (additive) over `<referenceBlock>` (replaces template).
+
+- `magewire.alpinejs.load` — Alpine JS bundle itself; themes reorder script tags here
+- `magewire.alpinejs` — global `$wire` / Alpine stores
+- `magewire.alpinejs.components` — reusable Alpine data components
+- `magewire.utilities` — helper registrations via `MagewireUtilities.register(...)`
+- `magewire.addons` — independent plugins via `MagewireAddons.register(...)`
+- `magewire.before` — user Alpine directives, UI components, custom wire:* directives
+- `magewire.internal.backwards-compatibility` — v1 BC shims only (JS hooks, event aliases)
+- `magewire.directives` — custom `wire:*` directives (Magewire-level, not Alpine)
+- `magewire.features` — feature-scoped bridge scripts (loaders, rate limiting, flash messages)
+- `magewire.after` — last-to-render theme content
+- `magewire.legacy`, `magewire.plugin.scripts` — pre-v3 plugin compatibility only
+
+### 3. Extension examples → `references/extension-examples.md`
+
+Copy-paste templates for the common integration patterns:
+
+- Bare theme compatibility module (registration + module.xml)
+- Theme-scoped Feature registered via `etc/{area}/di.xml` on `Magewirephp\Magewire\Features`
+- Observer on a theme event (e.g. `hyva_config_generate_before`) to bridge into the theme's build pipeline
+- Layout override via `default_{theme}.xml` — moving blocks, replacing templates, wrapping originals
+- Alpine-loading-order fix (common in Hyvä where Alpine must load before Magewire's own script)
+- PHTML override that preserves the original via `<?= $block->getChildHtml() ?>`
+
+### 4. Tailwind pipeline → `references/tailwind.md`
+
+- Core Tailwind config lives at `src/view/frontend/tailwind/tailwind.config.js` and scans `src/view/**/*.phtml|xml`
+- Theme modules add their own `themes/{Theme}/view/frontend/tailwind/tailwind.config.js` scanning only their own templates
+- Themes use `@source "../../../../../src/view"` in their `module.css` to inherit core classes
+- Theme-specific CSS variables override `--notifier-bg`, `--notifier-border`, etc. — no recompile needed if only colors change
+- For Hyvä, the `HyvaConfigGenerateBefore` observer registers Magewire's module path into Hyvä's Tailwind extension list so its classes are scanned at build time
+
+### 5. Sort order conventions
+
+When registering a theme-scoped Feature in DI, follow the existing numbering:
+
+- `1000–2000` — ported Livewire Features (do not use for theme code)
+- `5000–5200` — Magewire-specific Features (do not use for theme code)
+- `9900–9999` — theme Features that must run *before* BC
+- `99000+` — theme Features that must run *after* all core BC (Hyvä checkout BC is at `99200`)
+
+Use `sequence` in the DI `item` array to declare hard dependencies (e.g. `magewire_backwards_compatibility` must boot first).
+
+### 6. Area scoping (frontend vs adminhtml)
+
+Theme modules must register DI and layout under the right area:
+
+- `etc/frontend/di.xml` + `view/frontend/layout/` for storefront themes (Hyvä, Luma, Breeze)
+- `etc/adminhtml/di.xml` + `view/adminhtml/layout/` for backend themes
+- `etc/di.xml` (global) is never used for theme-scoped registration — Features registered globally leak into both areas
+
+Hyvä's `themes/Hyva/view/adminhtml/layout/default.xml` only adds its BC events; if a frontend-only theme doesn't need adminhtml wiring, omit the directory entirely.
+
+### 7. Adminhtml specifics (see `magewire-admin` package)
+
+Adminhtml diverges from frontend in several concrete ways. If you are writing admin Magewire code, read `references/extension-examples.md` sections 8–12 first:
+
+- **Update endpoint**: `/admin/magewire/update` (backend frontname prefix). Admin router must register its own `Controller/MagewireUpdateRouteAdminhtml` that extends the frontend controller and adds admin session validation via `Magento\Backend\Model\Auth\Session\Proxy`.
+- **Routes**: `etc/adminhtml/routes.xml` with `router id="admin"` and `front name="magewire"`.
+- **Script injection**: Admin templates render in `<head>` before `<body>`. Use a plugin on `Magento\Framework\View\Page\Config\Renderer::afterRenderAssets()` to inject the Magewire `<script>` tag before the first existing `<script>` — otherwise RequireJS loads before Alpine and component boot is racy.
+- **Component resolver**: Register a `LayoutAdminResolver` (extends `LayoutResolver`) with accessor `layout_admin` so admin layout XML uses `<magewire>layout_admin</magewire>` rather than `layout`. Resolver sort order `99800` so it runs before the default `99900` resolver.
+- **Page detection workaround**: Override `ResolveComponentsViewModel::doesPageHaveComponents()` to return `true` unconditionally — admin head-phase rendering evaluates this before body components exist, so the default heuristic reports no components and Mechanisms/Features never boot.
+- **Prototype.js pollution**: Magento admin loads Prototype.js, which pollutes `Object.prototype`. Register a RequireJS module that runs after `'prototype'` and restores `Object.keys` / `Object.values` to only enumerate own keys — otherwise Magewire child-component resolution iterates inherited properties and breaks.
+- **Update URI prefix**: Extend the Magewire `Utils\Magewire` view-model and override `getUpdateUri()` to prepend the backend frontname from `BackendConfigOptionsList::CONFIG_PATH_BACKEND_FRONTNAME`.
+- **No Tailwind**: Admin uses Magento's own CSS pipeline. Do not ship a Tailwind config for adminhtml theme modules.
+
+### 8. Recommendations discovered during research → `references/recommendations.md`
+
+Opportunities to tighten the theming story in the `magewirephp/magewire` codebase itself — things that bit us during exploration and would help future theme authors:
+
+- Extension points are implicit in layout XML; no authoritative list exists outside this skill
+- Feature sort-order tiers are a convention, not a constant — easy to drift
+- `magewire.features` doubles as block *and* container, which confuses override intent
+- No generic `SupportComponentBackwardsCompatibility` base — Hyvä's implementation is tightly coupled to `AbstractMagewireAddressForm`
+- Template override path convention (`overwrite/{Target_Module}/{path}`) is undocumented
+- No scaffolding command to generate a new theme module
+
+See `references/recommendations.md` for the full list with file references.
+
+## Anti-patterns
+
+- **Global DI for theme Features.** `etc/di.xml` leaks the Feature into both frontend and adminhtml. Always use `etc/frontend/di.xml` or `etc/adminhtml/di.xml`.
+- **Editing `src/view/base/layout/default.xml`** to add theme-specific blocks. That file is theme-agnostic. Add a `default_{theme}.xml` under the theme module and reference the core container.
+- **Raw `<script>` tags in theme PHTML.** The core `$magewireFragment->make()->script()` pattern applies everywhere — including theme modules. Breaking CSP on one theme breaks it for that theme's users.
+- **Hard-coding FQCNs of theme classes into `src/`.** The core must not reference `Magewirephp\MagewireCompatibilityWith*` classes. All coupling flows the other way — themes depend on core, never vice versa.
+- **Using `<referenceBlock>` when you only want to add a sibling.** `<referenceContainer>` appends without destroying the original template. Reserve `<referenceBlock>` for deliberate template replacement.
+- **Installing Magento modules for a theme via a separate composer package.** The `themes/{Theme}/` modules ship *inside* `magewirephp/magewire`; they are registered via that package's `composer.json` `autoload.psr-4` map. Do not create a standalone package unless you are forking.
+
+## When to load which reference
+
+- Creating a new theme module from scratch → `module-structure.md` then `extension-examples.md`
+- Adding a Feature, observer, or layout override to an existing theme module → `extension-examples.md`
+- Debugging where to plug a block in → `layout-containers.md`
+- CSS not applying / Tailwind classes missing → `tailwind.md`
+- Code review of Magewire theming code → read all reference files before writing review comments

--- a/.agents/skills/magewire-theming/references/extension-examples.md
+++ b/.agents/skills/magewire-theming/references/extension-examples.md
@@ -1,0 +1,540 @@
+# Extension Examples
+
+Copy-paste starting points for the common theme-module integration tasks. All examples are for a hypothetical `themes/MyTheme/` module with module name `Magewirephp_MagewireCompatibilityWithMyTheme`.
+
+## 1. Bare compatibility module
+
+Use when Magewire works out of the box on the theme and you only need to declare compatibility.
+
+**`themes/MyTheme/registration.php`**
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'Magewirephp_MagewireCompatibilityWithMyTheme',
+    __DIR__
+);
+```
+
+**`themes/MyTheme/etc/module.xml`**
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magewirephp_MagewireCompatibilityWithMyTheme">
+        <sequence>
+            <module name="Magewirephp_Magewire"/>
+        </sequence>
+    </module>
+</config>
+```
+
+## 2. Theme-scoped Feature registered via DI
+
+Use when you need to hook into component lifecycle for this theme only.
+
+**`themes/MyTheme/etc/frontend/di.xml`**
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magewirephp\Magewire\Features">
+        <arguments>
+            <argument name="items" xsi:type="array">
+                <item name="mytheme_feature" xsi:type="array">
+                    <item name="type" xsi:type="string">Magewirephp\MagewireCompatibilityWithMyTheme\Magewire\Features\SupportMyTheme\SupportMyTheme</item>
+                    <item name="sort_order" xsi:type="number">99100</item>
+                    <item name="sequence" xsi:type="array">
+                        <item name="magewire_backwards_compatibility" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
+</config>
+```
+
+**`themes/MyTheme/Magewire/Features/SupportMyTheme/SupportMyTheme.php`**
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\MagewireCompatibilityWithMyTheme\Magewire\Features\SupportMyTheme;
+
+use Magewirephp\Magewire\ComponentHook;
+use Magewirephp\Magewire\Component;
+use Magewirephp\Magewire\Mechanisms\HandleComponents\ComponentContext;
+
+class SupportMyTheme extends ComponentHook
+{
+    public function hydrate($memo): void
+    {
+        // Snapshot is being restored — read theme-specific memo flags here.
+        if (! isset($memo['mytheme']['flag'])) {
+            return;
+        }
+        // React to the flag.
+    }
+
+    public function dehydrate(ComponentContext $context): void
+    {
+        // Component is serializing — push theme-specific data into the snapshot memo.
+        $context->pushMemo('mytheme', true, 'flag');
+    }
+}
+```
+
+Area matters — put the `di.xml` under `etc/frontend/` for storefront themes and `etc/adminhtml/` for backend. Never under `etc/` alone.
+
+## 3. Observer bridging into a theme build event
+
+Use when the target theme publishes an event you can hook to register Magewire paths in its asset pipeline.
+
+**`themes/MyTheme/etc/frontend/events.xml`**
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="mytheme_config_generate_before">
+        <observer name="MagewirephpMagewireCompatibilityWithMyThemeConfigGenerateBefore"
+                  instance="Magewirephp\MagewireCompatibilityWithMyTheme\Observer\Frontend\ConfigGenerateBefore"/>
+    </event>
+</config>
+```
+
+**`themes/MyTheme/Observer/Frontend/ConfigGenerateBefore.php`**
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\MagewireCompatibilityWithMyTheme\Observer\Frontend;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class ConfigGenerateBefore implements ObserverInterface
+{
+    public function __construct(
+        private readonly ComponentRegistrar $componentRegistrar
+    ) {}
+
+    public function execute(Observer $event): void
+    {
+        $config = $event->getData('config');
+        $extensions = $config->hasData('extensions') ? $config->getData('extensions') : [];
+
+        $magewirePath = $this->componentRegistrar->getPath(
+            ComponentRegistrar::MODULE,
+            'Magewirephp_Magewire'
+        );
+
+        if ($magewirePath !== null) {
+            $extensions[] = ['src' => substr($magewirePath, strlen(BP) + 1)];
+        }
+
+        $config->setData('extensions', $extensions);
+    }
+}
+```
+
+`themes/Hyva/Observer/Frontend/HyvaConfigGenerateBefore.php` is the canonical reference for this pattern.
+
+## 4. Layout override: load Alpine before Magewire
+
+Pattern used by Hyvä. Applies when the target theme ships its own Alpine bundle that must load before Magewire's bundled Alpine hook.
+
+**`themes/MyTheme/view/frontend/layout/default_mytheme.xml`**
+```xml
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <!-- Reorder theme's Alpine script into Magewire's load slot -->
+        <move element="script-alpine-js" destination="magewire.alpinejs.load" before="-"/>
+
+        <!-- Wrap theme's Alpine template so Magewire can decide whether to render it -->
+        <referenceBlock name="script-alpine-js"
+                        template="Magewirephp_MagewireCompatibilityWithMyTheme::overwrite/MyTheme/page/js/alpinejs.phtml">
+            <block name="script-alpine-js-script"
+                   template="Magewirephp_MagewireCompatibilityWithMyTheme::script.phtml"
+                   after="-">
+                <block name="script-alpine-js-original"
+                       template="MyTheme::page/js/alpinejs.phtml"/>
+            </block>
+        </referenceBlock>
+    </body>
+</page>
+```
+
+**`themes/MyTheme/view/frontend/templates/overwrite/MyTheme/page/js/alpinejs.phtml`**
+```php
+<?php
+/**
+ * Defers Alpine init — renders child blocks so Magewire's bundled Alpine
+ * can take over when it's active, or falls back to the theme's own Alpine
+ * when Magewire is disabled on this page.
+ */
+?>
+<?= $block->getChildHtml() ?>
+```
+
+**`themes/MyTheme/view/frontend/templates/script.phtml`**
+```php
+<?php
+/** @var \Magento\Framework\View\Element\Template $block */
+/** @var \Magento\Framework\Escaper $escaper */
+/** @var \Magewirephp\Magewire\ViewModel\Utility $magewireUtility */
+
+$magewireUtility = $block->getData('magewire_utility');
+?>
+<?php if ($magewireUtility->canRequireMagewireJsLibrary()): ?>
+    <script
+        id="magewire-script"
+        src="<?= $escaper->escapeUrl($magewireUtility->mechanisms()->frontendAssets()->getScriptPath()) ?>"
+        x-data="magewireScript"
+        x-bind="magewireScriptBindings"
+    ></script>
+<?php else: ?>
+    <?= $block->getChildHtml() ?>
+<?php endif ?>
+```
+
+See `themes/Hyva/view/frontend/templates/script.phtml` for the production version.
+
+## 5. Registering a Feature-scoped bridge script
+
+Use when your theme Feature needs a companion JS file rendered into `magewire.features`.
+
+**`themes/MyTheme/view/frontend/layout/default_mytheme.xml`**
+```xml
+<referenceContainer name="magewire.features">
+    <block name="magewire.features.support-mytheme"
+           template="Magewirephp_MagewireCompatibilityWithMyTheme::magewire-features/support-mytheme/bridge.phtml"/>
+</referenceContainer>
+```
+
+**`themes/MyTheme/view/frontend/templates/magewire-features/support-mytheme/bridge.phtml`**
+```php
+<?php
+/** @var \Magewirephp\Magewire\ViewModel\Utility $magewireUtility */
+/** @var \Magento\Framework\Escaper $escaper */
+
+$magewireUtility = $block->getData('magewire_utility');
+$magewireFragment = $magewireUtility->utils()->fragment();
+$script = $magewireFragment->make()->script()->start();
+?>
+<script>
+    document.addEventListener('magewire:init', () => {
+        Magewire.hook('component.init', ({ component, cleanup }) => {
+            // Theme-specific init work here.
+        });
+    });
+</script>
+<?php $script->end(); ?>
+```
+
+The fragment-based script pattern is non-negotiable: it rewrites inline scripts into CSP-compliant form. Raw `<script>` tags will break on stores with CSP enabled.
+
+## 6. Page-specific Feature activation
+
+Use when a Feature should only boot on one route.
+
+**`themes/MyTheme/view/frontend/layout/mycheckout_index_index.xml`**
+```xml
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="magewire.features">
+            <container name="magewire.features.support-mycheckout">
+                <block name="magewire.features.support-mycheckout.components"
+                       template="Magewirephp_MagewireCompatibilityWithMyTheme::magewire-features/support-mycheckout/components.phtml"/>
+                <block name="magewire.features.support-mycheckout.events"
+                       template="Magewirephp_MagewireCompatibilityWithMyTheme::magewire-features/support-mycheckout/events.phtml"/>
+            </container>
+        </referenceContainer>
+    </body>
+</page>
+```
+
+Group related Feature templates inside a `<container>` so the theme can toggle the whole group with one `<remove>` or `<referenceContainer remove="true">`.
+
+## 7. Adminhtml theme module (lightweight)
+
+Mirror the frontend structure but under `etc/adminhtml/` and `view/adminhtml/`. If the module is adminhtml-only, drop `etc/frontend/` and `view/frontend/` entirely.
+
+**`themes/MyBackendTheme/etc/adminhtml/di.xml`** — same shape as `etc/frontend/di.xml` but the Feature typically hooks admin-only workflows.
+
+**`themes/MyBackendTheme/view/adminhtml/layout/default.xml`** — targets the same container names (`magewire.features`, `magewire.before`, etc.) because they're defined in `src/view/base/layout/default.xml`, which applies to both areas.
+
+See `themes/Hyva/view/adminhtml/layout/default.xml` for a minimal adminhtml example.
+
+For *real* admin integration (custom controller, session validation, plugin-based script injection), see sections 8–12 below — those patterns belong in a standalone package like `magewire-admin`, not in a `themes/` folder.
+
+## 8. Admin update controller with session validation
+
+For a standalone adminhtml package. Reuses the frontend controller's match conditions (POST + URI + JSON content type) and adds admin session validation.
+
+**`src/Controller/MagewireUpdateRouteAdminhtml.php`**
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\YourPackage\Controller;
+
+use Magento\Backend\App\Config as AdminConfig;
+use Magento\Backend\Model\Auth\Session\Proxy as AdminSessionProxy;
+use Magento\Framework\App\RequestInterface as Request;
+use Magewirephp\Magewire\Controller\MagewireUpdateRouteFrontend;
+
+class MagewireUpdateRouteAdminhtml extends MagewireUpdateRouteFrontend
+{
+    public function __construct(
+        private readonly AdminSessionProxy $sessionAuth,
+        ...$parentArgs
+    ) {
+        parent::__construct(...$parentArgs);
+    }
+
+    public function getMatchConditions(): array
+    {
+        return array_merge(parent::getMatchConditions(), [
+            'auth' => fn (Request $request): bool =>
+                $this->sessionAuth->getSessionId()
+                    === $request->getCookie(AdminConfig::SESSION_NAME_ADMIN),
+        ]);
+    }
+}
+```
+
+Form-key validation is not added. The combination of admin-session-cookie match + HTTP POST + JSON content type + same-origin is the frontline. If your threat model requires explicit CSRF tokens, add a `form_key` condition that compares the request header against `Magento\Framework\Data\Form\FormKey::getFormKey()`.
+
+**`src/etc/adminhtml/routes.xml`**
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="magewire" frontName="magewire">
+            <module name="Magewirephp_Magewire" before="Magento_Backend"/>
+        </route>
+    </router>
+</config>
+```
+
+**`src/etc/adminhtml/di.xml`** (route registration)
+```xml
+<type name="Magewirephp\Magewire\Controller\Router">
+    <arguments>
+        <argument name="routes" xsi:type="array">
+            <item name="magewire_update_adminhtml"
+                  xsi:type="object"
+                  sortOrder="20">
+                Vendor\YourPackage\Controller\MagewireUpdateRouteAdminhtml
+            </item>
+        </argument>
+    </arguments>
+</type>
+```
+
+## 9. Page\Config\Renderer plugin for head-phase script injection
+
+Admin renders `<head>` before `<body>`. Layout-XML `move` can't reorder between the head pipeline and RequireJS. A Magento core plugin is the only way.
+
+**`src/Plugin/Magento/Framework/View/Page/Config/Renderer.php`**
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\YourPackage\Plugin\Magento\Framework\View\Page\Config;
+
+use Magento\Framework\View\LayoutInterface;
+use Magento\Framework\View\Page\Config\Renderer as Subject;
+
+class Renderer
+{
+    public function __construct(private readonly LayoutInterface $layout) {}
+
+    public function afterRenderAssets(Subject $subject, string $result): string
+    {
+        $head = $this->layout->getBlock('magewire.head');
+        if ($head === false) {
+            return $result;
+        }
+
+        return preg_replace(
+            '/(<script\b[^>]*>)/i',
+            $head->toHtml() . '$1',
+            $result,
+            1
+        );
+    }
+}
+```
+
+Register in `src/etc/adminhtml/di.xml`:
+
+```xml
+<type name="Magento\Framework\View\Page\Config\Renderer">
+    <plugin name="magewire_admin_head_injection"
+            type="Vendor\YourPackage\Plugin\Magento\Framework\View\Page\Config\Renderer"
+            sortOrder="10"/>
+</type>
+```
+
+The regex injects once before the *first* `<script>`. If admin theming ever adds a `<script>` before any asset the Renderer handles, this might misfire — scope it tighter by matching on a known RequireJS script or include a sentinel comment in the layout head.
+
+## 10. RequireJS module to patch Prototype.js pollution
+
+Magento admin still loads Prototype.js, which adds enumerable properties to `Object.prototype`. This corrupts Magewire's child-component discovery (it iterates object keys to find nested components).
+
+**`src/view/adminhtml/requirejs-config.js`**
+```javascript
+var config = {
+    deps: [
+        'Vendor_YourPackage/js/fix-prototype-object-pollution'
+    ]
+};
+```
+
+**`src/view/adminhtml/web/js/fix-prototype-object-pollution.js`**
+```javascript
+define(['prototype'], function () {
+    'use strict';
+
+    const originalKeys = Object.keys;
+    const originalValues = Object.values;
+
+    Object.keys = function (obj) {
+        return originalKeys(obj).filter(key => Object.prototype.hasOwnProperty.call(obj, key));
+    };
+
+    Object.values = function (obj) {
+        return Object.keys(obj).map(key => obj[key]);
+    };
+});
+```
+
+The `['prototype']` dep guarantees this runs after Prototype.js has done its damage. Without this shim, Magewire child-component traversal in admin will iterate Prototype's injected methods as if they were child components and throw.
+
+## 11. Admin component resolver
+
+Declares a distinct accessor (`layout_admin`) so admin layout XML can bind components without colliding with frontend's `layout` accessor.
+
+**`src/Magewire/Mechanisms/ResolveComponents/ComponentResolver/LayoutAdminResolver.php`**
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\YourPackage\Magewire\Mechanisms\ResolveComponents\ComponentResolver;
+
+use Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolver\LayoutResolver;
+
+class LayoutAdminResolver extends LayoutResolver
+{
+    protected string $accessor = 'layout_admin';
+}
+```
+
+**`src/etc/adminhtml/di.xml`**
+```xml
+<type name="Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolverManagement">
+    <arguments>
+        <argument name="resolvers" xsi:type="array">
+            <item name="layout_admin" xsi:type="object" sortOrder="99800">
+                Vendor\YourPackage\Magewire\Mechanisms\ResolveComponents\ComponentResolver\LayoutAdminResolver
+            </item>
+        </argument>
+    </arguments>
+</type>
+```
+
+Sort order `99800` runs before the default `99900` so admin-accessor components resolve first. Admin components then declare:
+
+```xml
+<block name="admin.my.component" class="..." template="...">
+    <arguments>
+        <argument name="magewire" xsi:type="string">layout_admin</argument>
+    </arguments>
+</block>
+```
+
+## 12. Update URI prefix override
+
+Admin endpoints live under the backend frontname. The view-model utility that produces the `data-update-uri` attribute on the Magewire script tag needs to prefix the URI.
+
+**`src/Model/View/Utils/Magewire.php`**
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\YourPackage\Model\View\Utils;
+
+use Magento\Backend\Setup\ConfigOptionsList as BackendConfigOptionsList;
+use Magento\Framework\App\DeploymentConfig;
+use Magewirephp\Magewire\Model\View\Utils\Magewire as ParentUtility;
+
+class Magewire extends ParentUtility
+{
+    public function __construct(
+        private readonly DeploymentConfig $deploymentConfig,
+        ...$parentArgs
+    ) {
+        parent::__construct(...$parentArgs);
+    }
+
+    public function getUpdateUri(): string
+    {
+        return '/'
+            . $this->deploymentConfig->get(BackendConfigOptionsList::CONFIG_PATH_BACKEND_FRONTNAME)
+            . parent::getUpdateUri();
+    }
+}
+```
+
+Wire it via DI in `src/etc/adminhtml/di.xml`:
+
+```xml
+<preference for="Magewirephp\Magewire\Model\View\Utils\Magewire"
+            type="Vendor\YourPackage\Model\View\Utils\Magewire"/>
+```
+
+Preference is area-scoped — frontend keeps the original, admin gets the prefixed version.
+
+## 13. `ResolveComponentsViewModel` override
+
+Admin head-phase rendering evaluates "does this page have components?" before body components exist. Force-return `true` so Mechanisms and Features boot unconditionally in admin.
+
+**`src/Magewire/Mechanisms/ResolveComponents/ResolveComponentsViewModel.php`**
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\YourPackage\Magewire\Mechanisms\ResolveComponents;
+
+use Magewirephp\Magewire\Mechanisms\ResolveComponents\ResolveComponentsViewModel as ParentViewModel;
+
+class ResolveComponentsViewModel extends ParentViewModel
+{
+    public function doesPageHaveComponents(): bool
+    {
+        return true;
+    }
+}
+```
+
+Bind via `<preference>` in `src/etc/adminhtml/di.xml`. This is a known workaround, not a design. Track it — when Magewire grows a head-aware alternative, drop this override.

--- a/.agents/skills/magewire-theming/references/layout-containers.md
+++ b/.agents/skills/magewire-theming/references/layout-containers.md
@@ -1,0 +1,187 @@
+# Layout Containers
+
+The global `src/view/base/layout/default.xml` defines a tree of named containers and blocks that themes plug into. Knowing which one to target is the difference between an override that works and one that silently no-ops.
+
+## Container tree (simplified)
+
+```
+magewire (root block — src/view/base/templates/root.phtml)
+├── magewire.global
+│   ├── magewire.global.before
+│   │   ├── magewire.alpinejs.load           ← Alpine JS <script> tags
+│   │   ├── magewire.alpinejs                ← Alpine stores, $wire
+│   │   └── magewire.alpinejs.components     ← Alpine.data(...) registrations
+│   ├── magewire.utilities                   ← MagewireUtilities.register(...)
+│   └── magewire.addons                      ← MagewireAddons.register(...)
+├── magewire.before                          ← user Alpine directives / UI components
+├── magewire.internal
+│   └── magewire.internal.backwards-compatibility   ← v1 BC shims only
+├── magewire.directives                      ← Magewire wire:* directives
+├── magewire.features                        ← Feature-scoped bridge scripts
+├── magewire.after                           ← last-to-render theme content
+└── magewire.legacy
+    └── magewire.plugin.scripts              ← pre-v3 plugin compat only
+```
+
+Frontend layout (`src/view/frontend/layout/default.xml`) adds:
+
+- `magewire.alpinejs.components.magewire-script` inside `magewire.alpinejs.components`
+- `magewire.object-proxy` inside `after.body.start`
+- A `<move>` of the whole `magewire` block to `before.body.end`
+
+## Which to target
+
+| If you are… | Target | Why |
+|-------------|--------|-----|
+| Reordering Alpine bundle loading | `magewire.alpinejs.load` | Script tag order is controlled here. Hyvä moves the native Alpine script in. |
+| Registering a global JS helper | `magewire.utilities` or `magewire.addons` | Utilities = helpers consumed by other Magewire code. Addons = independent plugins. |
+| Adding an Alpine data component | `magewire.alpinejs.components` | Runs inside `alpine:init`. Your `Alpine.data('foo', ...)` lands here. |
+| Adding a reusable Alpine directive | `magewire.before` | User-scoped directives. Applied before core directives run. |
+| Adding a `wire:*` directive | `magewire.directives` | Magewire-level directive registration (e.g. `wire:select`). |
+| Bridging a Magewire Feature to its JS side | `magewire.features` | One child block per Feature, by convention. |
+| Shim v1 behavior (Livewire v2 quirks) | `magewire.internal.backwards-compatibility` | Internal container; not for general use. Reserved for BC code. |
+| Adding a plugin script for v1 compatibility | `magewire.plugin.scripts` | Pre-v3 plugins expect this container. |
+| Injecting theme-final content | `magewire.after` | Runs last, after everything Magewire-owned. |
+
+## `<referenceContainer>` vs `<referenceBlock>`
+
+```xml
+<!-- Adds a sibling block. Original content keeps rendering. -->
+<referenceContainer name="magewire.features">
+  <block name="magewire.features.my-bridge"
+         template="MyVendor_MyModule::magewire-features/my-bridge.phtml"/>
+</referenceContainer>
+
+<!-- Replaces the template. Original content is gone. -->
+<referenceBlock name="magewire.features.magewire-notifier"
+                template="MyVendor_MyModule::override-notifier.phtml"/>
+```
+
+Default to `<referenceContainer>`. Reach for `<referenceBlock>` only when you deliberately want to swap the template (e.g. overriding an upstream Alpine loader to wrap it).
+
+## Moving elements
+
+```xml
+<move element="script-alpine-js" destination="magewire.alpinejs.load" before="-"/>
+```
+
+`<move>` preserves the original block instance and re-parents it. Useful when an existing theme already renders a block somewhere else and you need it in Magewire's loading order.
+
+- `before="-"` = first child
+- `after="-"` = last child
+- `before="blockName"` / `after="blockName"` = relative to a sibling
+
+## Page-specific vs global overrides
+
+- `default_{theme}.xml` — applies on every page where the theme is active. Use for load-order fixes, global Feature bridges, BC shims.
+- `{route}_{controller}_{action}.xml` — applies on one route only. Use for page-scoped Features (e.g. Hyvä Checkout's BC feature is activated only on `hyva_checkout_index_index`).
+
+Smaller scope is cheaper — page-specific handles avoid paying for the block on every page.
+
+## Containers that are off-limits for themes
+
+- `magewire.internal` and anything under it (except the BC sub-container) — reserved for core machinery.
+- `magewire` root block itself — do not replace its template. Override children instead.
+
+If a container you need doesn't exist, add one in `default_{theme}.xml` as a child of an existing container rather than repurposing a reserved one.
+
+## Sort order within a container
+
+Magento layout XML honors `after=` / `before=` among siblings. For deterministic ordering within a container:
+
+```xml
+<block name="magewire.features.my-bridge"
+       template="..."
+       after="magewire.features.support-magewire-loaders"/>
+```
+
+Do not rely on file load order — that depends on module sequence and is brittle.
+
+## Adminhtml layout differences
+
+The base container tree defined in `src/view/base/layout/default.xml` applies to both frontend and adminhtml (base layouts merge into both areas). But admin adds two important deviations:
+
+### `magewire.head` — admin-only head container
+
+In admin, scripts must load in `<head>` before RequireJS. `magewire-admin` creates a `magewire.head` block holding the Magewire script tag and a sibling `magewire.script` child, then a plugin on `Page\Config\Renderer::afterRenderAssets()` injects the rendered block's HTML ahead of the first `<script>` tag in the output.
+
+```xml
+<!-- magewire-admin/src/view/adminhtml/layout/default.xml -->
+<move element="magewire" destination="root"/>
+
+<referenceContainer name="root">
+  <block name="magewire.head"
+         template="Magewirephp_MagewireAdmin::js/magewire/head.phtml">
+    <block name="magewire.script"
+           template="Magewirephp_MagewireAdmin::js/magewire/head/script.phtml"/>
+  </block>
+</referenceContainer>
+```
+
+The plugin then does:
+
+```php
+preg_replace('/(<script\b[^>]*>)/i', $head->toHtml() . '$1', $result, 1);
+```
+
+Frontend doesn't need this — layout XML's native ordering (`before.body.end`, `after.body.start`) is enough because the frontend has no RequireJS race.
+
+### `layout_admin` component accessor
+
+In frontend layout XML, components are bound with `<magewire>layout</magewire>`. In admin, the accessor is `layout_admin`:
+
+```xml
+<!-- admin layout XML -->
+<block name="my.admin.component"
+       class="Vendor\Module\Magewire\MyAdminComponent"
+       template="Vendor_Module::admin-component.phtml">
+    <arguments>
+        <argument name="magewire" xsi:type="string">layout_admin</argument>
+    </arguments>
+</block>
+```
+
+This works because `magewire-admin` registers a `LayoutAdminResolver` (sort order `99800`, before the default `99900` frontend resolver):
+
+```xml
+<!-- magewire-admin/src/etc/adminhtml/di.xml -->
+<type name="Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolverManagement">
+    <argument name="resolvers" xsi:type="array">
+        <item name="layout_admin" xsi:type="object" sortOrder="99800">
+            Magewirephp\MagewireAdmin\Magewire\Mechanisms\ResolveComponents\ComponentResolver\LayoutAdminResolver
+        </item>
+    </argument>
+</type>
+```
+
+If you're writing admin components without `magewire-admin` installed, they won't resolve. Require the package.
+
+### `doesPageHaveComponents()` always true in admin
+
+The base ViewModel decides whether to boot all Mechanisms/Features based on whether any components are present on the page. In admin, scripts render in the head before the body has been parsed — so the naive check reports zero components and Magewire skips the full boot. `magewire-admin` overrides the view model to always report `true`:
+
+```php
+// magewire-admin/src/Magewire/Mechanisms/ResolveComponents/ResolveComponentsViewModel.php
+public function doesPageHaveComponents(): bool
+{
+    return true;
+}
+```
+
+Do not copy this pattern into frontend theme modules — it would force-boot Magewire on every page including pure-static ones, wasting cycles.
+
+### Admin update URI
+
+Frontend posts to `/magewire/update`. Admin posts to `/{backend_frontname}/magewire/update` (typically `/admin/magewire/update`). The URI is produced by extending the view-model utility:
+
+```php
+// magewire-admin/src/Model/View/Utils/Magewire.php
+public function getUpdateUri(): string
+{
+    return '/' .
+        $this->deploymentConfig->get(BackendConfigOptionsList::CONFIG_PATH_BACKEND_FRONTNAME) .
+        parent::getUpdateUri();
+}
+```
+
+The rendered script tag consumes this via `data-update-uri`.

--- a/.agents/skills/magewire-theming/references/module-structure.md
+++ b/.agents/skills/magewire-theming/references/module-structure.md
@@ -1,0 +1,221 @@
+# Theme Module Structure
+
+A Magewire theme compatibility module is a standard Magento 2 module that lives under `themes/{Theme}/` inside the `magewirephp/magewire` package. It ships with the core package — it is not a separate composer install.
+
+## Minimum viable module
+
+Every theme module needs exactly these two files plus a PSR-4 autoload entry in the root `composer.json`.
+
+```
+themes/MyTheme/
+├── registration.php
+└── etc/
+    └── module.xml
+```
+
+### `registration.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'Magewirephp_MagewireCompatibilityWithMyTheme',
+    __DIR__
+);
+```
+
+### `etc/module.xml`
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magewirephp_MagewireCompatibilityWithMyTheme">
+        <sequence>
+            <module name="Magewirephp_Magewire"/>
+            <!-- Optional: the theme module(s) this compatibility layer targets -->
+            <!-- <module name="MyVendor_MyTheme"/> -->
+        </sequence>
+    </module>
+</config>
+```
+
+The `<sequence>` entry for `Magewirephp_Magewire` is load-bearing — without it, the core's DI and layout may boot after this module, and layout references will fail silently.
+
+If your compatibility layer targets a specific Magento theme module (e.g. `Hyva_Theme`), include it in the sequence so that theme's templates and layouts exist before yours tries to override them.
+
+### PSR-4 entry in root `composer.json`
+
+The root `magewirephp/magewire` composer file maps theme namespaces. Add your module:
+
+```json
+{
+  "autoload": {
+    "psr-4": {
+      "Magewirephp\\MagewireCompatibilityWithMyTheme\\": "themes/MyTheme/"
+    }
+  }
+}
+```
+
+Run `composer dump-autoload` after adding the mapping.
+
+## Naming conventions
+
+| Thing | Convention | Example |
+|-------|-----------|---------|
+| Directory | `themes/{Theme}` (PascalCase, no vendor prefix) | `themes/Hyva/` |
+| Module name | `Magewirephp_MagewireCompatibilityWith{Theme}` | `Magewirephp_MagewireCompatibilityWithHyva` |
+| PHP namespace | `Magewirephp\MagewireCompatibilityWith{Theme}\` | `Magewirephp\MagewireCompatibilityWithHyva\` |
+| Module alias in layout XML handle | `default_{lowercase_theme}.xml` | `default_hyva.xml` |
+| Template vendor prefix | `Magewirephp_MagewireCompatibilityWith{Theme}::` | `Magewirephp_MagewireCompatibilityWithHyva::script.phtml` |
+
+## Optional directories
+
+Add only what the theme actually needs.
+
+```
+themes/MyTheme/
+├── registration.php
+├── etc/
+│   ├── module.xml
+│   ├── frontend/
+│   │   ├── di.xml           # Register theme-scoped Features
+│   │   └── events.xml       # Observe theme build events (e.g. hyva_config_generate_before)
+│   └── adminhtml/
+│       └── di.xml           # Adminhtml Features (only for backend themes)
+├── Magewire/
+│   └── Features/
+│       └── Support.../      # ComponentHook subclasses scoped to this theme
+├── Observer/
+│   └── Frontend/
+│       └── *.php            # Bridge into theme build pipelines
+└── view/
+    ├── base/
+    │   └── templates/       # Shared across frontend + adminhtml
+    ├── frontend/
+    │   ├── layout/
+    │   │   ├── default_{theme}.xml       # Global theme overrides
+    │   │   └── {route}_{action}.xml      # Page-specific wiring
+    │   ├── templates/
+    │   │   ├── magewire-features/        # Feature-specific PHTML
+    │   │   ├── overwrite/{Target}/       # Overrides of other modules' templates
+    │   │   ├── js/                       # Theme-scoped JS PHTML
+    │   │   └── script.phtml
+    │   └── tailwind/
+    │       ├── tailwind.config.js        # Theme-only Tailwind content globs
+    │       ├── module.css                # Imports core via @source
+    │       └── ui-components/*.css
+    └── adminhtml/
+        └── layout/
+            └── default.xml
+```
+
+## Decision matrix
+
+| Goal | Files |
+|------|-------|
+| "Magewire works on Luma" statement | `registration.php` + `etc/module.xml` |
+| "Load Alpine before Magewire on Hyvä" | + `view/frontend/layout/default_{theme}.xml` |
+| "Run my BC hook only when a component renders under this theme's checkout" | + `etc/frontend/di.xml` + `Magewire/Features/Support.../*.php` |
+| "Scan my theme's PHTML with Tailwind" | + `view/frontend/tailwind/*` |
+| "Tell the theme's asset pipeline where Magewire's templates are" | + `Observer/Frontend/*.php` + `etc/frontend/events.xml` |
+| "Serve a theme-specific flash-message bridge" | + `view/frontend/templates/magewire-features/*.phtml` + layout reference |
+
+## Reference implementations
+
+- Deepest in-tree integration: `themes/Hyva/` — BC features, observers, template overrides, Tailwind wiring
+- Bare minimum (markers): `themes/Luma/`, `themes/Breeze/`, `themes/Backend/` — registration + module.xml only
+- Standalone admin integration: `magewirephp/magewire-admin` (separate composer package) — controllers, plugins, custom resolver, RequireJS workaround
+
+When you copy from Hyvä, strip out what isn't needed for your theme. Do not ship empty containers or unused observer classes.
+
+## Standalone admin-integration package
+
+Adminhtml integration doesn't fit the `themes/{Theme}/` mould. The canonical package is `magewirephp/magewire-admin` — it ships outside the main magewire repo and is required separately.
+
+### When to use standalone over in-tree
+
+| Trigger | Choose |
+|---------|--------|
+| Theme ships own CSS pipeline, different build config, or overrides Magewire layout containers | In-tree `themes/{Theme}/` |
+| Target is adminhtml, requires custom controller, admin session validation, or plugin on Magento core classes | Standalone package |
+| Need per-release versioning decoupled from main magewire cadence | Standalone package |
+| Target is experimental or third-party, unsuitable for the main repo | Standalone package |
+
+### Standalone package shape (based on `magewire-admin`)
+
+```
+magewirephp/magewire-admin/
+├── composer.json                        # type: magento2-module
+├── README.md
+└── src/
+    ├── registration.php                 # module name: Magewirephp_MagewireAdmin
+    ├── Controller/
+    │   └── MagewireUpdateRouteAdminhtml.php   # extends frontend controller + admin session check
+    ├── Magewire/
+    │   └── Mechanisms/
+    │       └── ResolveComponents/
+    │           ├── ComponentResolver/
+    │           │   └── LayoutAdminResolver.php     # accessor: layout_admin
+    │           └── ResolveComponentsViewModel.php  # overrides doesPageHaveComponents() → true
+    ├── Model/
+    │   └── View/Utils/Magewire.php      # prefixes update URI with backend frontname
+    ├── Plugin/
+    │   └── Magento/Framework/View/Page/Config/Renderer.php   # injects head block before first <script>
+    ├── etc/
+    │   ├── module.xml                   # sequence: Magento_Backend, Magewirephp_Magewire
+    │   └── adminhtml/
+    │       ├── di.xml                   # registers resolver + custom route
+    │       └── routes.xml               # router: admin, frontName: magewire
+    └── view/
+        └── adminhtml/
+            ├── requirejs-config.js      # loads Prototype.js pollution fix as global dep
+            ├── layout/default.xml       # creates magewire.head container, moves magewire into root
+            ├── templates/
+            │   ├── dashboard/magewire.phtml
+            │   └── js/magewire/{head.phtml, head/script.phtml}
+            └── web/
+                └── js/fix-prototype-object-pollution.js   # restores Object.keys/values
+```
+
+### Standalone `composer.json` template
+
+```json
+{
+    "name": "vendor/your-package",
+    "type": "magento2-module",
+    "description": "Magewire integration for X",
+    "license": "MIT",
+    "require": {
+        "php": ">=8.1",
+        "magento/framework": "*",
+        "magewirephp/magewire": "^3.0"
+    },
+    "autoload": {
+        "files": ["src/registration.php"],
+        "psr-4": {
+            "Vendor\\YourPackage\\": "src/"
+        }
+    }
+}
+```
+
+Always pin a minimum `magewirephp/magewire` version. The current `magewire-admin` `composer.json` omits this — that's a trap for future upgraders.
+
+### What is NOT in a theme module (in-tree)
+
+Do not put the following in `themes/{Theme}/` — they belong in a standalone package:
+
+- Custom controllers extending Magewire's update controller
+- Plugins on Magento core classes (`Page\Config\Renderer`, router, session)
+- Custom Mechanisms or Component Resolvers
+- View Model overrides of core Magewire view models
+- RequireJS config files (JS bundle management)
+
+`themes/Hyva/` gets away with an observer (`HyvaConfigGenerateBefore`) because it hooks a theme-owned event, not a Magento core class. That's the line.

--- a/.agents/skills/magewire-theming/references/recommendations.md
+++ b/.agents/skills/magewire-theming/references/recommendations.md
@@ -1,0 +1,176 @@
+# Recommendations
+
+Opportunities to improve Magewire's theming story — surfaced while researching this skill. These are not bugs; they are friction points that would make future theme modules easier to author and less error-prone.
+
+Each item names where the friction lives and suggests a concrete change.
+
+## 1. No authoritative list of extension points
+
+**Where**: `src/view/base/layout/default.xml` defines ~12 public containers but the names are scattered across the XML with no class-level documentation block or README.
+
+**Friction**: A theme author has to read the whole layout file and guess which containers are "public" vs "internal". Two containers (`magewire.internal`, `magewire.legacy`) are reserved but nothing in the XML signals that.
+
+**Suggestion**: Add XML comments above each container tagged `<!-- public extension point -->` or `<!-- internal — do not override -->`. Alternatively, expose a PHP constant map (e.g. `Magewirephp\Magewire\Layout\Containers::EXTENSION_POINTS`) that theme code can consume programmatically.
+
+## 2. Feature sort-order tiers are a convention, not a constant
+
+**Where**: CLAUDE.md names three tiers (`1000–2000`, `5000–5200`, `99000+`) but they exist only in prose. `themes/Hyva/etc/frontend/di.xml` picks `99200` empirically.
+
+**Friction**: A new theme module author has no authoritative source for "what number should I use?" A drift where two themes pick the same sort order and override each other is invisible until a bug report.
+
+**Suggestion**: Ship a PHP constants class:
+
+```php
+namespace Magewirephp\Magewire\Features;
+
+final class SortOrder
+{
+    public const LIVEWIRE_BASE        = 1000;
+    public const LIVEWIRE_MAX         = 2000;
+    public const MAGEWIRE_CORE        = 5000;
+    public const MAGEWIRE_CORE_MAX    = 5200;
+    public const THEME_EARLY          = 9900;
+    public const THEME_LATE           = 99200;
+}
+```
+
+Reference it in `etc/di.xml` using `<item xsi:type="const">...::THEME_LATE</item>` so sort-order choices are self-documenting.
+
+## 3. `magewire.features` is both a block and a container
+
+**Where**: `src/view/base/layout/default.xml` defines `magewire.features` as a `<block>` with a template, but it's routinely used as a `<referenceContainer>` target.
+
+**Friction**: `<referenceContainer name="magewire.features">` works, but `<referenceBlock name="magewire.features">` also works — and does something different. A junior dev picks the wrong one, replaces the whole feature template, and silently loses every registered feature.
+
+**Suggestion**: Split into two — a `<container name="magewire.features">` (pure layout container) and, if a block template is genuinely needed, a sibling `magewire.features.root` block inside it. Update layout references throughout.
+
+## 4. No generic backwards-compatibility Feature base
+
+**Where**: `themes/Hyva/Magewire/Features/SupportHyvaCheckoutBackwardsCompatibility/SupportHyvaCheckoutBackwardsCompatibility.php` is tightly coupled to `AbstractMagewireAddressForm` — it checks `instanceof AbstractMagewireAddressForm` and merges events from `dispatchBrowserEvent()`.
+
+**Friction**: Any other theme that wants "v1 components run in a v3 world" has to copy this whole class and edit the `instanceof` check. The generic BC plumbing (memo flag, layout-container inheritance) gets duplicated.
+
+**Suggestion**: Extract an abstract `AbstractComponentBackwardsCompatibility extends ComponentHook` in `lib/Magewire/Features/` with:
+- a `protected function appliesTo(Component $component): bool` template method (returns `true` by default)
+- a `protected function containerHandles(): array` template method (returns layout handles that activate BC, empty by default)
+- the existing memo push + hydration logic
+
+Hyvä's class becomes a 15-line subclass overriding the two hooks. New themes get a 15-line subclass for free.
+
+## 5. Undocumented template override path convention
+
+**Where**: Hyvä places overrides at `themes/Hyva/view/frontend/templates/overwrite/Hyva_Theme/page/js/alpinejs.phtml`. The `overwrite/{TargetModule}/{original-path}` pattern is a convention in this codebase but appears nowhere in documentation.
+
+**Friction**: Magento's template fallback is based on `view/{area}/templates/{Module}::path`, not on an `overwrite/` directory. A reader sees `overwrite/Hyva_Theme/...` and assumes it's magical. It isn't — it's cosmetic, and the actual override works because `default_hyva.xml` references it by `Magewirephp_MagewireCompatibilityWithHyva::overwrite/Hyva_Theme/...`.
+
+**Suggestion**: Either document the `overwrite/` convention in the `magewire-theming` skill (done here in `extension-examples.md` §4) or rename to a flatter structure like `templates/hyva/alpinejs.phtml`. Documenting is cheaper and keeps the visual grouping benefit.
+
+## 6. No scaffolding command to generate a new theme module
+
+**Where**: `vendor/bin/portman` has subcommands for building the ported Livewire tree but none for generating a theme module skeleton.
+
+**Friction**: Creating a new theme compat module means copying six files by hand, renaming strings in five of them, and remembering to touch the root `composer.json` PSR-4 map. High friction, low-variance work.
+
+**Suggestion**: Add `portman theme:create --name=MyTheme` that:
+- creates `themes/MyTheme/registration.php`, `etc/module.xml`
+- adds PSR-4 mapping to root `composer.json`
+- prompts for "minimal | with-feature | with-hyva-style-observer" and emits additional scaffolding accordingly
+- runs `composer dump-autoload` at the end
+
+Saves every new theme author an hour and eliminates the class of "I forgot the PSR-4 entry" bugs.
+
+## 7. Luma / Breeze / Backend modules are effectively empty
+
+**Where**: `themes/Luma/`, `themes/Breeze/`, `themes/Backend/` all contain only `registration.php` + `etc/module.xml`.
+
+**Friction**: Readers assume these modules must do *something* theme-specific since they exist. They don't — they're marker modules declaring that Magewire is compatible.
+
+**Suggestion**: Add a one-line comment in each `module.xml` (e.g. `<!-- Compatibility marker. Magewire needs no theme-specific integration on Luma. -->`) or a minimal README.md. Alternatively, collapse them into a single `themes/Compat/` module with multiple `<module>` declarations — though that may conflict with Magento's one-module-per-directory expectation.
+
+## 8. Adminhtml theming story is thin
+
+**Where**: Only `themes/Hyva/view/adminhtml/layout/default.xml` exists, and it only wires BC events. No adminhtml-first theme module demonstrates what a backend integration looks like.
+
+**Friction**: A developer building a Magewire component for the admin panel has no template to follow. They don't know which containers render in adminhtml (they all do, because the containers are in `view/base/`), whether `magewire.alpinejs` is relevant (it is, Alpine works in admin), or whether observers on `hyva_config_generate_before`-style events exist (they don't, admin has no equivalent).
+
+**Suggestion**: Either (a) add adminhtml examples to this skill's `extension-examples.md` showing a working admin Magewire component + theme wiring, or (b) promote `themes/Backend/` from a marker module to a live adminhtml reference implementation with one small Feature.
+
+## 9. Tailwind `@source` inheritance is not discoverable
+
+**Where**: `themes/Hyva/view/frontend/tailwind/module.css` uses `@source "../../../../../src/view";`. This is Tailwind v4's way of sharing scanning sets across projects, but the path is fragile (relative to compile location) and undocumented.
+
+**Friction**: A developer copies Hyvä's config to a new theme, Tailwind strips all Magewire classes because the relative path no longer resolves, and the only symptom is a broken notifier style.
+
+**Suggestion**: Either (a) centralize in a `tailwind-preset.js` that themes `require()` — idiomatic Tailwind — or (b) document the relative-path contract explicitly with a comment: `/* keeps Magewire utilities in this theme's Tailwind build; path is relative from compiled CSS output */`.
+
+## 10. `themes/` path is PSR-4-mapped via root composer.json, not via Magento
+
+**Where**: `composer.json` at the package root has entries like `Magewirephp\\MagewireCompatibilityWithHyva\\: themes/Hyva/`. This is correct but non-obvious — a reader opening `themes/Hyva/` and not finding a local `composer.json` expects autoload to be broken.
+
+**Friction**: New theme authors create `themes/NewTheme/composer.json` thinking it's required, then wonder why it causes install issues.
+
+**Suggestion**: Add a `themes/README.md` (one paragraph) explaining: "Theme modules are installed as part of the parent `magewirephp/magewire` package. Their PSR-4 mappings live in the root `composer.json`. Do not create a per-theme `composer.json`."
+
+---
+
+None of these are blockers. The current setup works and Hyvä ships. But each is a paper-cut that theme authors will hit, and fixing any of them makes the second, third, and tenth theme module faster to build than the first one was.
+
+---
+
+## 11. `themes/Backend/` is vestigial; `magewire-admin` is the real thing
+
+**Where**: `themes/Backend/` in the main `magewirephp/magewire` package contains only `registration.php` + `etc/module.xml`. The canonical admin integration lives in the separate `magewirephp/magewire-admin` composer package.
+
+**Friction**: A developer sees `themes/Backend/` and assumes it provides admin integration. It doesn't. They discover `magewire-admin` only after investigating why their admin Magewire component doesn't boot.
+
+**Suggestion**: One of:
+- Deprecate `themes/Backend/` with a README pointing to `magewire-admin`
+- Fold `magewire-admin`'s Mechanisms, plugin, and resolver into the main package under `src/etc/adminhtml/` so adminhtml works out of the box (standalone package stays for theme-specific admin customization only)
+- Expand `themes/Backend/` to require `magewire-admin` transitively so a composer install of the bundled marker pulls in real functionality
+
+The third option preserves the current install story and ends the confusion.
+
+## 12. `magewire-admin` `composer.json` has no version constraint on magewire
+
+**Where**: `vendor/magewirephp/magewire-admin/composer.json` has no `require` section pinning `magewirephp/magewire`.
+
+**Friction**: A project can install an incompatible pair (e.g. magewire-admin built for 3.0 running against magewire 4.x) and get silent runtime breakage — the `Controller` or `Mechanism` base classes may have moved.
+
+**Suggestion**: Add:
+
+```json
+"require": {
+    "php": ">=8.1",
+    "magento/framework": "*",
+    "magewirephp/magewire": "^3.0"
+}
+```
+
+Run CI on both the lowest-supported and latest magewire version to keep the constraint honest.
+
+## 13. `doesPageHaveComponents()` override lacks an exit criterion
+
+**Where**: `magewire-admin/src/Magewire/Mechanisms/ResolveComponents/ResolveComponentsViewModel.php` unconditionally returns `true` to force full boot in admin head-phase rendering.
+
+**Friction**: This is a workaround, not a design. The code has no comment explaining why, no issue link, and no condition under which it should be removed. Future maintainers will either leave it forever or remove it prematurely.
+
+**Suggestion**: Add a docblock citing the cause (head-phase rendering evaluates before body component parsing) and the exit criterion (e.g. "remove when magewire supports a deferred resolver for head-phase scripts, tracked in ISSUE-###"). Ideally also a feature flag so users can opt back to the upstream behavior if admin changes shape.
+
+## 14. Prototype.js fix would fit better as a Magewire Feature
+
+**Where**: `magewire-admin/src/view/adminhtml/web/js/fix-prototype-object-pollution.js` is loaded as a top-level RequireJS dep via `requirejs-config.js`.
+
+**Friction**: The fix is all-or-nothing — can't be disabled via config, not overridable by themes that want a different strategy (e.g. Luma admin with a patched Prototype.js), and not testable in isolation.
+
+**Suggestion**: Wrap it in a Magewire Feature registered via `Magewirephp\Magewire\Features` DI. The Feature renders the shim into `magewire.internal` (or a new `magewire.internal.polyfills` container) only when the target environment is detected (presence of `Prototype` global). That makes it:
+- Disableable via the same DI mechanism that toggles other Features
+- Testable in isolation
+- Skippable on admin pages that don't load Prototype (if any)
+
+## 15. Admin auth uses session cookie comparison, not form key
+
+**Where**: `MagewireUpdateRouteAdminhtml::getMatchConditions()` checks `sessionAuth->getSessionId() === request->getCookie(SESSION_NAME_ADMIN)`.
+
+**Friction**: This is *approximately* CSRF protection — the cookie is set server-side after admin login, so a cross-origin attacker can't forge it. But Magento's convention is explicit form-key validation on admin forms. Security reviewers doing an audit will flag this as "form-key missing" unless they understand the equivalence.
+
+**Suggestion**: Add a docblock on the controller explaining the threat model: session cookie comparison + POST + JSON content type is equivalent to form-key for this endpoint because admin sessions are HTTP-only and same-origin. Alternatively, add form-key validation as a defense-in-depth measure (negligible perf cost, easier to reason about). Either way, make the decision visible in code, not just in the author's head.

--- a/.agents/skills/magewire-theming/references/tailwind.md
+++ b/.agents/skills/magewire-theming/references/tailwind.md
@@ -1,0 +1,119 @@
+# Tailwind Pipeline
+
+Magewire compiles one base stylesheet (`src/view/base/web/css/magewire.css`) using Tailwind v4. Theme modules extend this pipeline by scanning their own templates and, optionally, overriding CSS variables.
+
+## Core pipeline
+
+### Config
+
+**`src/view/frontend/tailwind/tailwind.config.js`**
+```js
+module.exports = {
+  content: [
+    '../../../../src/view/base/layout/**/*.xml',
+    '../../../../src/view/base/templates/**/*.phtml',
+    '../../../../src/view/frontend/layout/**/*.xml',
+    '../../../../src/view/frontend/templates/**/*.phtml',
+  ]
+};
+```
+
+### Build
+
+```bash
+npm install
+npx @tailwindcss/cli \
+  -i ./styles/magewire.css \
+  -o ./src/view/base/web/css/magewire.css \
+  --optimize
+```
+
+This compiles to `src/view/base/web/css/magewire.css` — a flat CSS file Magento serves as a static asset.
+
+## Theme-scoped Tailwind config
+
+When a theme adds its own PHTML templates with Tailwind classes, those classes must be scanned during build. Each theme module can ship its own Tailwind config.
+
+### `themes/{Theme}/view/frontend/tailwind/tailwind.config.js`
+
+```js
+module.exports = {
+  content: [
+    '../../../../themes/{Theme}/view/frontend/templates/**/*.phtml'
+  ]
+};
+```
+
+The path is relative from the CSS entry file. Verify by running the CLI from the theme directory and checking that theme-only class names appear in the output.
+
+### `themes/{Theme}/view/frontend/tailwind/module.css`
+
+```css
+@source "../../../../../src/view";
+@import "./ui-components/notifier.css";
+```
+
+`@source` is Tailwind v4's inheritance directive — it imports the scan set from the core package so the theme gets the same utility classes plus its own. Without `@source`, the theme's Tailwind build will strip all classes Magewire relies on.
+
+## CSS variable overrides
+
+Magewire's CSS exposes theming hooks through CSS custom properties. For color/spacing changes, overriding variables beats recompiling.
+
+```css
+/* themes/{Theme}/view/frontend/web/css/overrides.css */
+.magewire-notifier__notification {
+  --notifier-bg: #f0f9ff;
+  --notifier-border: #0284c7;
+  --notifier-title: #075985;
+}
+
+.magewire-notifier__notification--success {
+  --notifier-bg: #ecfdf5;
+  --notifier-border: #059669;
+  --notifier-title: #047857;
+}
+```
+
+See `src/view/base/web/css/magewire.css` lines 638–800 for the full list of supported variables on the notifier and related components.
+
+## Hyvä Tailwind integration
+
+Hyvä's Tailwind build scans all registered modules listed in its `extensions` config. Magewire hooks `hyva_config_generate_before` so its paths are injected automatically:
+
+**`themes/Hyva/Observer/Frontend/HyvaConfigGenerateBefore.php`** (simplified):
+
+```php
+public function execute(Observer $event): void
+{
+    $config = $event->getData('config');
+    $extensions = $config->hasData('extensions') ? $config->getData('extensions') : [];
+
+    $magewirePath = $this->componentRegistrar->getPath(
+        ComponentRegistrar::MODULE,
+        'Magewirephp_Magewire'
+    );
+
+    $extensions[] = ['src' => substr($magewirePath, strlen(BP) + 1)];
+
+    $config->setData('extensions', $extensions);
+}
+```
+
+This tells Hyvä's Tailwind compiler to scan Magewire's templates alongside the theme's own. Without this observer, Magewire-authored classes would be stripped as "unused" during Hyvä's build.
+
+When creating a new theme compat module that targets a Hyvä-like build pipeline (any theme that scans a curated list of modules rather than all vendor/), copy this observer pattern.
+
+## When not to use Tailwind
+
+- Backend themes (`themes/Backend/`) don't need Tailwind — adminhtml UI is styled by Magento's own CSS.
+- Luma/Breeze already compile CSS via their own LESS/SCSS toolchains. A Magewire theme compat module for those typically does not add a Tailwind config — instead, it ships prebuilt CSS or uses CSS variables.
+
+## Debug checklist
+
+If Tailwind classes aren't applying in a theme:
+
+1. Confirm the theme's `tailwind.config.js` `content` globs actually match your PHTML paths.
+2. Confirm `@source` in `module.css` points at `src/view` (relative paths bite here).
+3. Rebuild: `npx @tailwindcss/cli -i ... -o ...`.
+4. Check the compiled CSS file for the missing class name. If it's absent, scanning is broken. If present, it's a precedence or caching issue.
+5. Flush Magento's `var/view_preprocessed` and `pub/static` caches; re-deploy static content.

--- a/.agents/skills/magewire/SKILL.md
+++ b/.agents/skills/magewire/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: magewire
+description: "Reference for Magewire — Magento 2's reactive component framework inspired by Laravel Livewire v3. Use when building, debugging, or explaining Magewire components, wire:* directives, lifecycle hooks, events, loading states, or any PHP/JS component API. Auto-load when working in a Magewire component class or PHTML template."
+requires: magewire-portman
+---
+
+# Magewire
+
+Magewire is a reactive component framework for Magento 2, heavily inspired by Laravel Livewire v3. It enables full-stack reactive UI without writing JavaScript — components are PHP classes that render PHTML templates, communicate with the server over AJAX, and re-render in place using Alpine.js as the reactive glue.
+
+---
+
+## Core Concept
+
+A Magewire component is a PHP class that:
+- Holds public properties as reactive state
+- Exposes public methods callable from the frontend
+- Renders a PHTML template
+- Survives across requests via a serialized snapshot
+
+When the user interacts with the UI (e.g. fills a form, clicks a button), the frontend sends the current snapshot + the pending updates/calls to `magewire/update`. The server hydrates the component, applies changes, re-renders, and returns the new HTML and snapshot. Alpine.js morphs the DOM in place.
+
+---
+
+## Creating a Component
+
+```php
+namespace Vendor\Module\Magewire;
+
+use Magewirephp\Magewire\Component;
+
+class Counter extends Component
+{
+    public int $count = 0;
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+}
+```
+
+Register it in layout XML (Magewire can be bound to any block class):
+
+```xml
+<block name="my.counter"
+       template="Vendor_Module::counter.phtml">
+    <arguments>
+        <argument name="magewire" xsi:type="object">Vendor\Module\Magewire\Counter</argument>
+    </arguments>
+</block>
+```
+
+Template (`counter.phtml`):
+
+```html
+<div>
+    <span><?= $magewire->count ?></span>
+    <button wire:click="increment">+</button>
+</div>
+```
+
+The component's root element must be a single HTML element. The `$magewire` variable is the component instance.
+
+---
+
+## Public Properties
+
+Public properties are automatically serialized into the snapshot and are two-way bindable from the frontend.
+
+```php
+public string $name = '';
+public int $quantity = 1;
+public array $items = [];
+```
+
+Bind in template:
+
+```html
+<input wire:model="name" type="text">
+<input wire:model.live="quantity" type="number">
+```
+
+- `wire:model` — binds on form submit / next request
+- `wire:model.live` — binds on every change (triggers AJAX immediately)
+- `wire:model.blur` — binds on blur
+
+---
+
+## Public Methods
+
+Any public method can be called from the frontend:
+
+```html
+<button wire:click="save">Save</button>
+```
+
+Methods can also be triggered on other events:
+
+```html
+<input wire:keydown.enter="search">
+<form wire:submit="submit">
+```
+
+---
+
+## Lifecycle Hooks
+
+All hooks are optional. Define them as public methods on your component:
+
+| Hook | When it fires |
+|------|--------------|
+| `boot()` | Every request, before mount/hydrate |
+| `booted()` | Every request, after boot/hydrate sequence |
+| `initialize()` | Every request, before mount/hydrate |
+| `mount(array $params)` | Initial render only |
+| `hydrate()` | Every subsequent request (not initial) |
+| `hydrateXxx()` | Hydrate for a specific property (e.g. `hydrateName`) |
+| `updating($prop, $value)` | Before any property update |
+| `updatingXxx($value)` | Before a specific property updates (e.g. `updatingName`) |
+| `updated($prop, $value)` | After any property update |
+| `updatedXxx($value)` | After a specific property updates |
+| `rendering($view, $data)` | Before template is rendered |
+| `rendered($view, $html)` | After template is rendered |
+| `dehydrate()` | Before state is serialized back to snapshot |
+| `dehydrateXxx()` | Dehydrate for specific property |
+| `exception(\Throwable $e, callable $stopPropagation)` | On exception |
+
+Dot-notation property hooks use studly case: `updatingFooBar` for `foo.bar` (dots are replaced, then the whole string is converted to StudlyCase).
+
+---
+
+## Skipping Lifecycle Phases
+
+```php
+public function mount(): void
+{
+    $this->skipRender();  // Don't re-render after this request
+    $this->skipMount();   // Skip the mount phase
+    $this->skipHydrate(); // Skip hydrate
+}
+```
+
+---
+
+## Events
+
+Dispatch to other components on the same page:
+
+```php
+$this->dispatch('cart-updated', itemCount: 3);
+```
+
+Listen in another component:
+
+```php
+#[On('cart-updated')]
+public function onCartUpdated(int $itemCount): void
+{
+    $this->count = $itemCount;
+}
+```
+
+The `#[On]` attribute is the preferred listener API. A `protected $listeners = [...]` array on the component is also supported (legacy v1 style) but discouraged for new code.
+
+Dispatch to self:
+
+```php
+$this->dispatch('refreshed')->self();
+```
+
+Dispatch to parent:
+
+```php
+$this->dispatch('saved')->up();
+```
+
+---
+
+## Nested Components
+
+Magewire supports parent-child component relationships. The child component is embedded as a block inside the parent's template. The parent can access children, and events can bubble up via `->up()`.
+
+---
+
+## Redirects
+
+```php
+public function save(): void
+{
+    // ... save logic
+    $this->redirect('/success');
+}
+```
+
+---
+
+## Notifications
+
+Magewire provides a fluent notification API via the `SupportMagewireNotifications` feature. Access it through the `magewireNotifications()` method on your component:
+
+```php
+// Create a notice (default type)
+$this->magewireNotifications()->make(__('Item saved successfully'));
+
+// Create with a specific type using fluent builders
+$this->magewireNotifications()->make(__('Order placed'))->asSuccess();
+$this->magewireNotifications()->make(__('Something went wrong'))->asError();
+$this->magewireNotifications()->make(__('Check your input'))->asWarning();
+
+// Full fluent API
+$this->magewireNotifications()
+    ->make(__('Order #123 confirmed'))
+    ->asSuccess()
+    ->withTitle(__('Order Confirmation'))
+    ->withDuration(5000); // milliseconds (default: 3000)
+
+// Named notifications (prevents duplicates with the same name)
+$this->magewireNotifications()->make(__('Saving...'), 'save-progress');
+```
+
+Available type methods: `asSuccess()`, `asError()`, `asWarning()`, `asNotice()`, or `as(NotificationType $type)`.
+Additional builders: `withTitle()`, `withoutTitle()`, `withDuration()`.
+
+---
+
+## Loading States
+
+Wire directives control loading feedback automatically:
+
+```html
+<button wire:click="save" wire:loading.attr="disabled">Save</button>
+<div wire:loading>Saving...</div>
+<div wire:loading.remove>Ready</div>
+```
+
+Target specific actions:
+
+```html
+<div wire:loading wire:target="save">Saving...</div>
+```
+
+---
+
+## Rate Limiting
+
+The `SupportMagewireRateLimiting` feature provides configurable rate limiting for Magewire update requests. It is configured via Magento's admin system configuration and DI, not via PHP attributes on components.
+
+---
+
+## ViewModel Utilities
+
+The `SupportMagewireViewModel` feature auto-injects a `MagewireViewModel` as `view_model` on every component block. Access it from your component via `magewireViewModel()`, or from templates via `$block->getData('view_model')`.
+
+The view model provides access to a rich set of utilities via `utils()`:
+
+```php
+// From a component class
+$this->magewireViewModel()->utils()->magewire();     // Magewire runtime access (mechanisms, config, update URI)
+$this->magewireViewModel()->utils()->template();     // Template compilation utilities
+$this->magewireViewModel()->utils()->layout();       // Layout information
+$this->magewireViewModel()->utils()->fragment();     // CSP-compliant script fragment builder
+$this->magewireViewModel()->utils()->security();     // CSRF token, security helpers
+$this->magewireViewModel()->utils()->env();          // Environment mode checks (developer, production)
+$this->magewireViewModel()->utils()->alpinejs();     // Alpine.js integration helpers
+$this->magewireViewModel()->utils()->csp();          // CSP nonce generation
+$this->magewireViewModel()->utils()->tailwind();     // Tailwind CSS utilities
+$this->magewireViewModel()->utils()->application();  // Application-level utilities
+```
+
+From PHTML templates, the common pattern is:
+
+```php
+$magewireViewModel = $block->getData('view_model');
+$magewireFragment  = $magewireViewModel->utils()->fragment();
+```
+
+---
+
+## JavaScript Hooks
+
+Access Magewire's JS lifecycle from custom scripts using the `magewire:init` event:
+
+```javascript
+document.addEventListener('magewire:init', event => {
+    // Hook into every server roundtrip
+    Magewire.hook('commit', ({ component, commit, respond, succeed, fail }) => {
+        // Runs on every component update request
+    });
+});
+```
+
+Register a custom **addon** (reactive shared state, accessible as `Magewire.addons.myAddon`):
+
+```javascript
+document.addEventListener('magewire:init', () =>
+    Magewire.addon('myAddon', function() {
+        return { value: null, set(v) { this.value = v; } };
+    }, true), // true wraps in Alpine.reactive()
+    { once: true }
+);
+```
+
+Register a custom **utility** (accessible as `MagewireUtilities.dom`):
+
+```javascript
+document.addEventListener('alpine:init', () =>
+    window.MagewireUtilities.register('dom', function() {
+        return { filterDataAttributes(el, prefix) { return {}; } };
+    }),
+    { once: true }
+);
+```
+
+---
+
+## Key Differences from Livewire v3
+
+- Components are Magento **blocks**, not Laravel routes
+- Uses **PHTML** templates, not Blade
+- Request routing goes through **Magento's controller system** (`magewire/update`)
+- CSRF uses Magento's **FormKey**, not Livewire's token
+- Flash messages go through **Magento session**
+- Layout and block management use **Magento's layout XML system**
+- The PHP core is ported from Livewire via **Portman** (see `magewire-portman` skill)
+- JavaScript is an **unmodified copy** of Livewire's JS bundle, served as a Magento static asset (kept untouched so Livewire upgrades can be adopted by replacing the file)

--- a/lib/Magewire/Features/SupportMagewireViewModel/MagewireViewModel.php
+++ b/lib/Magewire/Features/SupportMagewireViewModel/MagewireViewModel.php
@@ -20,6 +20,9 @@ class MagewireViewModel implements MagewireViewModelInterface
     ) {
     }
 
+    /**
+     * Magewire utility gateway.
+     */
     public function utils(string|null $name = null, array $arguments = []): ViewUtils
     {
         return $name ? $this->utils->$name($arguments) : $this->utils;

--- a/lib/Magewire/Mechanisms/HandleCompiling/View/Directive.php
+++ b/lib/Magewire/Mechanisms/HandleCompiling/View/Directive.php
@@ -107,4 +107,5 @@ abstract class Directive
 
         return $var;
     }
+
 }

--- a/lib/Magewire/Mechanisms/HandleCompiling/View/Directive.php
+++ b/lib/Magewire/Mechanisms/HandleCompiling/View/Directive.php
@@ -107,5 +107,4 @@ abstract class Directive
 
         return $var;
     }
-
 }

--- a/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Magewire/Component.php
+++ b/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Magewire/Component.php
@@ -15,6 +15,7 @@ use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\Directive\Parser\Expres
 use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirective;
 use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirectiveChain;
 use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirectiveParser;
+use Magewirephp\Magewire\Support\Php;
 
 class Component extends ScopeDirective
 {
@@ -24,8 +25,11 @@ class Component extends ScopeDirective
     {
         $var = $this->variableScopeStart($variable);
         $prefix ??= 'default';
+        $prefix = Php::stringLiteral($prefix);
+        $type = Php::stringLiteral((string) $type);
+        $id = Php::stringLiteral($id);
 
-        return "<?php \${$var} = \$__magewire->factory()->components()->component(prefix: '{$prefix}', block: \$block, type: '{$type}', id: '{$id}')->track() ?>";
+        return "<?php \${$var} = \$__magewire->factory()->components()->component(prefix: {$prefix}, block: \$block, type: {$type}, id: {$id})->track() ?>";
     }
 
     public function endComponent(): string

--- a/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Magewire/Slot.php
+++ b/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Magewire/Slot.php
@@ -15,6 +15,7 @@ use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\Directive\Parser\Expres
 use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirective;
 use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirectiveChain;
 use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirectiveParser;
+use Magewirephp\Magewire\Support\Php;
 
 class Slot extends ScopeDirective
 {
@@ -24,7 +25,7 @@ class Slot extends ScopeDirective
     {
         $var = $this->variableScopeStart($variable);
 
-        return "<?php \${$var} = \$__magewire->factory()->components()->slot('{$target}', \$block) ?>";
+        return "<?php \${$var} = \$__magewire->factory()->components()->slot(" . Php::stringLiteral($target) . ", \$block) ?>";
     }
 
     public function endSlot(): string

--- a/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Script.php
+++ b/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Script.php
@@ -40,7 +40,7 @@ class Script extends ScopeDirective
 
     private function placementExpression(mixed $placement): string
     {
-        if (is_array($placement) && ($placement['type'] ?? null) === 'variable') {
+        if (is_array($placement) && ( $placement['type'] ?? null ) === 'variable') {
             return Php::variable($placement['name']);
         }
 

--- a/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Script.php
+++ b/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Script.php
@@ -11,19 +11,43 @@ declare(strict_types=1);
 
 namespace Magewirephp\Magewire\Mechanisms\HandleCompiling\View\Directive;
 
+use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\Directive\Parser\ExpressionParserType;
 use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirective;
 use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirectiveChain;
+use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\ScopeDirectiveParser;
+use Magewirephp\Magewire\Support\Php;
+use UnexpectedValueException;
 
 class Script extends ScopeDirective
 {
     #[ScopeDirectiveChain(['endscript'])]
-    public function script(): string
+    #[ScopeDirectiveParser(ExpressionParserType::FUNCTION_ARGUMENTS)]
+    public function script(mixed $placement = null): string
     {
-        return "<?php \${$this->var('fragment')} = \$__magewire->utils()->fragment()->make()->script()->start() ?>";
+        $script = "\$__magewire->utils()->fragment()->make()->script()";
+
+        if ($placement !== null) {
+            $script .= sprintf('->placement(%s)', $this->placementExpression($placement));
+        }
+
+        return "<?php \${$this->var('fragment')} = {$script}->start() ?>";
     }
 
     public function endscript(): string
     {
         return "<?php \${$this->var('fragment')}->end() ?>";
+    }
+
+    private function placementExpression(mixed $placement): string
+    {
+        if (is_array($placement) && ($placement['type'] ?? null) === 'variable') {
+            return Php::variable($placement['name']);
+        }
+
+        if (is_string($placement)) {
+            return Php::stringLiteral($placement);
+        }
+
+        throw new UnexpectedValueException('The @script(placement: ...) argument must be a string or variable expression.');
     }
 }

--- a/lib/Magewire/Support/Php.php
+++ b/lib/Magewire/Support/Php.php
@@ -48,9 +48,7 @@ class Php
         $isList = array_is_list($value);
 
         foreach ($value as $key => $item) {
-            $items[] = $isList
-                ? self::valueLiteral($item)
-                : self::valueLiteral($key) . ' => ' . self::valueLiteral($item);
+            $items[] = $isList ? self::valueLiteral($item) : self::valueLiteral($key) . ' => ' . self::valueLiteral($item);
         }
 
         return '[' . implode(', ', $items) . ']';

--- a/lib/Magewire/Support/Php.php
+++ b/lib/Magewire/Support/Php.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Support;
+
+use InvalidArgumentException;
+
+class Php
+{
+    /**
+     * Encode a value as a single-quoted PHP string literal for generated code.
+     */
+    public static function stringLiteral(string $value): string
+    {
+        return "'" . str_replace(['\\', "'"], ['\\\\', "\\'"], $value) . "'";
+    }
+
+    /**
+     * Encode a PHP value as source code for generated code.
+     */
+    public static function valueLiteral(mixed $value): string
+    {
+        return match (true) {
+            is_string($value) => self::stringLiteral($value),
+            is_int($value) => (string) $value,
+            is_float($value) => self::floatLiteral($value),
+            is_bool($value) => $value ? 'true' : 'false',
+            $value === null => 'null',
+            is_array($value) => self::arrayLiteral($value),
+            default => throw new InvalidArgumentException(sprintf('Unable to compile %s as a PHP literal.', get_debug_type($value)))
+        };
+    }
+
+    /**
+     * Encode a PHP array as short array syntax for generated code.
+     */
+    public static function arrayLiteral(array $value): string
+    {
+        $items = [];
+        $isList = array_is_list($value);
+
+        foreach ($value as $key => $item) {
+            $items[] = $isList
+                ? self::valueLiteral($item)
+                : self::valueLiteral($key) . ' => ' . self::valueLiteral($item);
+        }
+
+        return '[' . implode(', ', $items) . ']';
+    }
+
+    /**
+     * Convert a variable name to a PHP variable expression.
+     */
+    public static function variable(string $name): string
+    {
+        $name = ltrim($name, '$');
+
+        if (! preg_match('/^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$/', $name)) {
+            throw new InvalidArgumentException(sprintf('Invalid PHP variable name [%s].', $name));
+        }
+
+        return '$' . $name;
+    }
+
+    /**
+     * Wrap generated code in a PHP tag.
+     */
+    public static function tag(string $code): string
+    {
+        return "<?php {$code} ?>";
+    }
+
+    /**
+     * Wrap an expression in a PHP echo tag.
+     */
+    public static function echoTag(string $expression): string
+    {
+        return self::tag("echo {$expression}");
+    }
+
+    private static function floatLiteral(float $value): string
+    {
+        if (! is_finite($value)) {
+            throw new InvalidArgumentException('Unable to compile a non-finite float as a PHP literal.');
+        }
+
+        return var_export($value, true);
+    }
+}

--- a/src/Controller/Playwright/Placements.php
+++ b/src/Controller/Playwright/Placements.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Controller\Playwright;
+
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magewirephp\Magewire\Controller\MagewireDeveloperAction;
+
+class Placements extends MagewireDeveloperAction implements HttpGetActionInterface
+{
+    protected string $pageTitle = 'Magewire / Playwright / Placements';
+}

--- a/src/Magewire/Playwright/Placements/Basic.php
+++ b/src/Magewire/Playwright/Placements/Basic.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Magewire\Playwright\Placements;
+
+use Magewirephp\Magewire\Component;
+
+class Basic extends Component
+{
+}

--- a/src/Model/View/Fragment.php
+++ b/src/Model/View/Fragment.php
@@ -15,6 +15,7 @@ use Magento\Framework\Escaper;
 use Magewirephp\Magewire\Concerns\WithTagging;
 use Magewirephp\Magewire\Model\View\Fragment\Exceptions\EmptyFragmentException;
 use Magewirephp\Magewire\Model\View\Fragment\Exceptions\FragmentValidationException;
+use Magewirephp\Magewire\Model\View\Management\SlotsManager;
 use Magewirephp\Magewire\Support\DataCollection;
 use Magewirephp\Magewire\Support\Factory;
 use Magewirephp\Magewire\Support\Random;
@@ -51,12 +52,16 @@ abstract class Fragment
 
     /**
      * @param array<int|string, FragmentModifier|callable> $modifiers
+     *
+     * @mago-expect lint:excessive-parameter-list
      */
     public function __construct(
         protected LoggerInterface $logger,
         protected Escaper $escaper,
         private array $modifiers = [],
-        private string|null $id = null
+        private string|null $id = null,
+        private SlotsManager|null $slotsManager = null,
+        private PlacementRegistry|null $placementRegistry = null
     ) {
     }
 
@@ -164,6 +169,19 @@ abstract class Fragment
     protected function getRawOutput(): string
     {
         return $this->raw === false ? '' : $this->raw;
+    }
+
+    /**
+     * Slots entry point.
+     */
+    protected function slots(): SlotsRegistry
+    {
+        return ($this->slotsManager ??= Factory::get(SlotsManager::class))->registry();
+    }
+
+    protected function placements(): PlacementRegistry
+    {
+        return $this->placementRegistry ??= Factory::get(PlacementRegistry::class);
     }
 
     /**

--- a/src/Model/View/Fragment.php
+++ b/src/Model/View/Fragment.php
@@ -53,7 +53,6 @@ abstract class Fragment
     /**
      * @param array<int|string, FragmentModifier|callable> $modifiers
      *
-     * @mago-expect lint:excessive-parameter-list
      */
     public function __construct(
         protected LoggerInterface $logger,
@@ -176,7 +175,7 @@ abstract class Fragment
      */
     protected function slots(): SlotsRegistry
     {
-        return ($this->slotsManager ??= Factory::get(SlotsManager::class))->registry();
+        return ( $this->slotsManager ??= Factory::get(SlotsManager::class) )->registry();
     }
 
     protected function placements(): PlacementRegistry

--- a/src/Model/View/Fragment.php
+++ b/src/Model/View/Fragment.php
@@ -15,7 +15,6 @@ use Magento\Framework\Escaper;
 use Magewirephp\Magewire\Concerns\WithTagging;
 use Magewirephp\Magewire\Model\View\Fragment\Exceptions\EmptyFragmentException;
 use Magewirephp\Magewire\Model\View\Fragment\Exceptions\FragmentValidationException;
-use Magewirephp\Magewire\Model\View\Management\SlotsManager;
 use Magewirephp\Magewire\Support\DataCollection;
 use Magewirephp\Magewire\Support\Factory;
 use Magewirephp\Magewire\Support\Random;
@@ -52,14 +51,12 @@ abstract class Fragment
 
     /**
      * @param array<int|string, FragmentModifier|callable> $modifiers
-     *
      */
     public function __construct(
         protected LoggerInterface $logger,
         protected Escaper $escaper,
         private array $modifiers = [],
         private string|null $id = null,
-        private SlotsManager|null $slotsManager = null,
         private PlacementRegistry|null $placementRegistry = null
     ) {
     }
@@ -171,13 +168,8 @@ abstract class Fragment
     }
 
     /**
-     * Slots entry point.
+     * Placements entry point.
      */
-    protected function slots(): SlotsRegistry
-    {
-        return ( $this->slotsManager ??= Factory::get(SlotsManager::class) )->registry();
-    }
-
     protected function placements(): PlacementRegistry
     {
         return $this->placementRegistry ??= Factory::get(PlacementRegistry::class);

--- a/src/Model/View/Fragment/Concern/Placeable.php
+++ b/src/Model/View/Fragment/Concern/Placeable.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Model\View\Fragment\Concern;
+
+use Magewirephp\Magewire\Model\View\PlacementEntry;
+use Magewirephp\Magewire\Model\View\PlacementRegistry;
+use Magewirephp\Magewire\Support\Factory;
+
+trait Placeable
+{
+    private string|null $placement = null;
+
+    abstract protected function placements(): PlacementRegistry;
+
+    public function placement(string $placement): static
+    {
+        $this->placement = $placement;
+
+        return $this;
+    }
+
+    public function for(string $placement): static
+    {
+        return $this->placement($placement);
+    }
+
+    protected function echo(string $output): void
+    {
+        if ($this->placement === null) {
+            echo $output;
+            return;
+        }
+
+        $entry = Factory::create(PlacementEntry::class, [
+            'content' => $output,
+            'scope' => 'script',
+            'name' => $this->placement
+        ]);
+
+        $this->placements()->script($this->placement, $entry);
+
+        echo $entry->sourceComment();
+    }
+}

--- a/src/Model/View/Fragment/PlaceableFragmentInterface.php
+++ b/src/Model/View/Fragment/PlaceableFragmentInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Model\View\Fragment;
+
+interface PlaceableFragmentInterface
+{
+    /**
+     * Transfer the rendered script fragment output into a named script placement.
+     */
+    public function placement(string $placement): static;
+
+    /**
+     * Alias for {@see placement()}.
+     */
+    public function for(string $placement): static;
+}

--- a/src/Model/View/Fragment/Script.php
+++ b/src/Model/View/Fragment/Script.php
@@ -11,8 +11,12 @@ declare(strict_types=1);
 
 namespace Magewirephp\Magewire\Model\View\Fragment;
 
-class Script extends Html
+use Magewirephp\Magewire\Model\View\Fragment\Concern\Placeable;
+
+class Script extends Html implements PlaceableFragmentInterface
 {
+    use Placeable;
+
     private string|null $code = null;
 
     public function start(): static

--- a/src/Model/View/Placement/Proxy/Script.php
+++ b/src/Model/View/Placement/Proxy/Script.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Model\View\Placement\Proxy;
+
+use Magewirephp\Magewire\Model\View\PlacementBuffer;
+use Magewirephp\Magewire\Model\View\PlacementProxyInterface;
+use Magewirephp\Magewire\Model\View\PlacementRegistry;
+
+class Script implements PlacementProxyInterface
+{
+    /**
+     * Add rendered script-fragment output to a named script placement.
+     *
+     * Called through {@see PlacementRegistry::__call()} as
+     * `$registry->script($name, $content)`.
+     *
+     * @param string $arguments[0] The script placement name, for example `default`.
+     * @param string|\Stringable $arguments[1] The already-rendered script fragment output to append.
+     */
+    public function __invoke(PlacementRegistry $registry, mixed ...$arguments): PlacementBuffer
+    {
+        return $registry->add('script', ...$arguments);
+    }
+}

--- a/src/Model/View/PlacementBuffer.php
+++ b/src/Model/View/PlacementBuffer.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Model\View;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Stringable;
+use Traversable;
+
+/**
+ * @implements IteratorAggregate<int, PlacementEntry>
+ */
+class PlacementBuffer implements Countable, IteratorAggregate, Stringable
+{
+    /** @var array<int, PlacementEntry> */
+    private array $entries = [];
+
+    public function __construct(
+        private readonly string $scope,
+        private readonly string $name
+    ) {
+    }
+
+    public function scope(): string
+    {
+        return $this->scope;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function add(PlacementEntry $entry): static
+    {
+        $this->entries[] = $entry;
+
+        return $this;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->entries === [];
+    }
+
+    public function count(): int
+    {
+        return count($this->entries);
+    }
+
+    /**
+     * @return array<int, PlacementEntry>
+     */
+    public function all(): array
+    {
+        return $this->entries;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->all());
+    }
+
+    public function __toString(): string
+    {
+        return implode('', array_map(static fn (PlacementEntry $entry): string => (string) $entry, $this->all()));
+    }
+}

--- a/src/Model/View/PlacementEntry.php
+++ b/src/Model/View/PlacementEntry.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Model\View;
+
+use Magento\Framework\App\State as ApplicationState;
+use Magewirephp\Magewire\Support\Random;
+use Stringable;
+
+readonly class PlacementEntry implements Stringable
+{
+    private string $code;
+
+    public function __construct(
+        private ApplicationState $applicationState,
+        private string $content,
+        private string|null $scope = null,
+        private string|null $name = null,
+        string|null $code = null
+    ) {
+        $this->code = $code ?? Random::alphabetical(8, true);
+    }
+
+    public function __toString(): string
+    {
+        if ($this->isProductionMode()) {
+            return $this->content;
+        }
+
+        return $this->content . PHP_EOL . $this->comment(sprintf(
+            'Magewire: Script placement "%s".',
+            $this->code
+        ));
+    }
+
+    public function sourceComment(): string
+    {
+        if ($this->isProductionMode()) {
+            return '';
+        }
+
+        return $this->comment(sprintf(
+            'Magewire: Script "%s" transferred to "%s".',
+            $this->code,
+            $this->name ?? 'unknown',
+        ));
+    }
+
+    private function isProductionMode(): bool
+    {
+        return $this->applicationState->getMode() === ApplicationState::MODE_PRODUCTION;
+    }
+
+    private function comment(string $text): string
+    {
+        return '<!-- ' . str_replace('--', '- -', $text) . ' -->';
+    }
+}

--- a/src/Model/View/PlacementEntry.php
+++ b/src/Model/View/PlacementEntry.php
@@ -35,10 +35,7 @@ readonly class PlacementEntry implements Stringable
             return $this->content;
         }
 
-        return $this->content . PHP_EOL . $this->comment(sprintf(
-            'Magewire: Script placement "%s".',
-            $this->code
-        ));
+        return $this->content . PHP_EOL . $this->comment(sprintf('Magewire: Script placement "%s".', $this->code));
     }
 
     public function sourceComment(): string
@@ -47,11 +44,7 @@ readonly class PlacementEntry implements Stringable
             return '';
         }
 
-        return $this->comment(sprintf(
-            'Magewire: Script "%s" transferred to "%s".',
-            $this->code,
-            $this->name ?? 'unknown',
-        ));
+        return $this->comment(sprintf('Magewire: Script "%s" transferred to "%s".', $this->code, $this->name ?? 'unknown'));
     }
 
     private function isProductionMode(): bool

--- a/src/Model/View/PlacementProxyInterface.php
+++ b/src/Model/View/PlacementProxyInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Model\View;
+
+interface PlacementProxyInterface
+{
+    public function __invoke(PlacementRegistry $registry, mixed ...$arguments): mixed;
+}

--- a/src/Model/View/PlacementRegistry.php
+++ b/src/Model/View/PlacementRegistry.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Model\View;
+
+use BadMethodCallException;
+use Magewirephp\Magewire\Support\Factory;
+use Stringable;
+
+/**
+ * @method PlacementBuffer script(string $name, string|Stringable $content)
+ */
+class PlacementRegistry
+{
+    private const MARKER_PREFIX = 'MAGEWIRE_PLACEMENT';
+
+    /** @var array<string, PlacementBuffer> */
+    private array $buffers = [];
+
+    /** @var array<string, array{scope: string, name: string}> */
+    private array $placeholders = [];
+
+    /**
+     * @param array<string, PlacementProxyInterface> $proxies
+     */
+    public function __construct(
+        private array $proxies = []
+    ) {
+    }
+
+    public function add(string $scope, string $name, string|Stringable $content): PlacementBuffer
+    {
+        if (! $content instanceof PlacementEntry) {
+            $content = Factory::create(PlacementEntry::class, [
+                'content' => (string) $content,
+                'scope' => $scope,
+                'name' => $name
+            ]);
+        }
+
+        return $this->buffer($scope, $name)->add($content);
+    }
+
+    public function has(string $scope, string $name): bool
+    {
+        $key = $this->key($scope, $name);
+
+        return array_key_exists($key, $this->buffers) && ! $this->buffers[$key]->isEmpty();
+    }
+
+    public function render(string $scope, string $name): string
+    {
+        return $this->placeholder($scope, $name);
+    }
+
+    public function resolve(string $html): string
+    {
+        foreach ($this->placeholders as $placeholder => $target) {
+            $html = str_replace($placeholder, (string) $this->buffer($target['scope'], $target['name']), $html);
+        }
+
+        return $html;
+    }
+
+    private function buffer(string $scope, string $name): PlacementBuffer
+    {
+        $key = $this->key($scope, $name);
+
+        return $this->buffers[$key] ??= Factory::create(PlacementBuffer::class, [
+            'scope' => $scope,
+            'name' => $name
+        ]);
+    }
+
+    private function placeholder(string $scope, string $name): string
+    {
+        $placeholder = sprintf('<!-- %s:%s -->', self::MARKER_PREFIX, hash('xxh3', $this->key($scope, $name)));
+        $this->placeholders[$placeholder] = ['scope' => $scope, 'name' => $name];
+
+        return $placeholder;
+    }
+
+    private function key(string $scope, string $name): string
+    {
+        return $scope . ':' . $name;
+    }
+
+    /**
+     * @throws BadMethodCallException
+     */
+    public function __call(string $proxy, array $arguments = []): mixed
+    {
+        if (array_key_exists($proxy, $this->proxies)) {
+            return ($this->proxies[$proxy])($this, ...$arguments);
+        }
+
+        throw new BadMethodCallException(sprintf('Placement proxy "%s" was called but does not exist.', $proxy));
+    }
+}

--- a/src/Model/View/PlacementRegistry.php
+++ b/src/Model/View/PlacementRegistry.php
@@ -99,7 +99,7 @@ class PlacementRegistry
     public function __call(string $proxy, array $arguments = []): mixed
     {
         if (array_key_exists($proxy, $this->proxies)) {
-            return ($this->proxies[$proxy])($this, ...$arguments);
+            return $this->proxies[$proxy]($this, ...$arguments);
         }
 
         throw new BadMethodCallException(sprintf('Placement proxy "%s" was called but does not exist.', $proxy));

--- a/src/Model/View/Slot.php
+++ b/src/Model/View/Slot.php
@@ -203,7 +203,7 @@ class Slot implements Stringable, IteratorAggregate, Countable
      */
     public function getIterator(): Traversable
     {
-        return new ArrayIterator($this->content);
+        return new ArrayIterator($this->all());
     }
 
     /**

--- a/src/Model/View/SlotsRegistry.php
+++ b/src/Model/View/SlotsRegistry.php
@@ -37,7 +37,7 @@ class SlotsRegistry
     /** @var array<string, Component> */
     private array $components = [];
 
-    // At the moment; only for registration purposes only.
+    // At the moment; for registration purposes only.
     private array $completed = [];
 
     private string $area = 'root-0';

--- a/src/Model/View/Utils/Fragment.php
+++ b/src/Model/View/Utils/Fragment.php
@@ -13,12 +13,16 @@ namespace Magewirephp\Magewire\Model\View\Utils;
 
 use InvalidArgumentException;
 use Magewirephp\Magewire\Model\View\FragmentFactory;
+use Magewirephp\Magewire\Model\View\PlacementRegistry;
 use Magewirephp\Magewire\Model\View\UtilsInterface;
 
 class Fragment implements UtilsInterface
 {
+    private const PLACEMENT_SCOPE_SCRIPT = 'script';
+
     public function __construct(
-        private readonly FragmentFactory $fragmentFactory
+        private readonly FragmentFactory $fragmentFactory,
+        private readonly PlacementRegistry $placementRegistry
     ) {
     }
 
@@ -42,5 +46,25 @@ class Fragment implements UtilsInterface
         }
 
         return $this->fragmentFactory;
+    }
+
+    public function has(string $name): bool
+    {
+        return $this->placementRegistry->has(self::PLACEMENT_SCOPE_SCRIPT, $name);
+    }
+
+    public function render(string $name): string
+    {
+        return $this->script($name);
+    }
+
+    public function container(string $name): string
+    {
+        return $this->script($name);
+    }
+
+    public function script(string $name): string
+    {
+        return $this->placementRegistry->render(self::PLACEMENT_SCOPE_SCRIPT, $name);
     }
 }

--- a/src/Plugin/Magento/Framework/App/PageCache/Kernel.php
+++ b/src/Plugin/Magento/Framework/App/PageCache/Kernel.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Plugin\Magento\Framework\App\PageCache;
+
+use Magento\Framework\App\PageCache\Kernel as Subject;
+use Magento\Framework\App\Response\Http as ResponseHttp;
+use Magewirephp\Magewire\Model\View\PlacementRegistry;
+
+class Kernel
+{
+    public function __construct(
+        private readonly PlacementRegistry $placementRegistry
+    ) {
+    }
+
+    public function beforeProcess(Subject $subject, ResponseHttp $response): array
+    {
+        $content = $response->getContent();
+
+        if (is_string($content) && $content !== '') {
+            $response->setContent($this->placementRegistry->resolve($content));
+        }
+
+        return [$response];
+    }
+}

--- a/src/Plugin/Magento/Framework/App/Response/Http.php
+++ b/src/Plugin/Magento/Framework/App/Response/Http.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Plugin\Magento\Framework\App\Response;
+
+use Magento\Framework\App\Response\Http as Subject;
+use Magewirephp\Magewire\Model\View\PlacementRegistry;
+
+class Http
+{
+    public function __construct(
+        private readonly PlacementRegistry $placementRegistry
+    ) {
+    }
+
+    public function beforeSendResponse(Subject $subject): void
+    {
+        $content = $subject->getContent();
+
+        if (is_string($content) && $content !== '') {
+            $subject->setContent($this->placementRegistry->resolve($content));
+        }
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -66,4 +66,24 @@
                 type="Magewirephp\Magewire\Plugin\Magento\Framework\View\TemplateEngine\Php"
         />
     </type>
+
+    <type name="Magewirephp\Magewire\Model\View\PlacementRegistry">
+        <arguments>
+            <argument name="proxies" xsi:type="array">
+                <item name="script" xsi:type="object">Magewirephp\Magewire\Model\View\Placement\Proxy\Script</item>
+            </argument>
+        </arguments>
+    </type>
+
+    <type name="Magento\Framework\App\Response\Http">
+        <plugin name="Magewirephp_Magewire_Plugin_Magento_Framework_App_Response_Http"
+                type="Magewirephp\Magewire\Plugin\Magento\Framework\App\Response\Http"
+        />
+    </type>
+
+    <type name="Magento\Framework\App\PageCache\Kernel">
+        <plugin name="Magewirephp_Magewire_Plugin_Magento_Framework_App_PageCache_Kernel"
+                type="Magewirephp\Magewire\Plugin\Magento\Framework\App\PageCache\Kernel"
+        />
+    </type>
 </config>

--- a/src/view/base/layout/default.xml
+++ b/src/view/base/layout/default.xml
@@ -28,6 +28,18 @@
         <block name="magewire"
                template="Magewirephp_Magewire::root.phtml"
         >
+            <container name="magewire.placements" as="placements">
+                <block name="magewire.placement.default"
+                       template="Magewirephp_Magewire::placements/default.phtml"
+                >
+                    <arguments>
+                        <argument name="view_model" xsi:type="object">
+                            Magewirephp\Magewire\Features\SupportMagewireViewModel\MagewireViewModelInterface
+                        </argument>
+                    </arguments>
+                </block>
+            </container>
+
             <block name="magewire.global"
                    as="global"
                    template="Magewirephp_Magewire::js/magewire/global.phtml"

--- a/src/view/base/templates/placements/default.phtml
+++ b/src/view/base/templates/placements/default.phtml
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\View\Element\Template;
+use Magewirephp\Magewire\Features\SupportMagewireViewModel\MagewireViewModelInterface;
+
+/** @var Template $block */
+/** @var MagewireViewModelInterface $viewModel */
+
+$viewModel = $block->getData('view_model');
+?>
+<?= $viewModel->utils()->fragment()->script('default') ?>

--- a/src/view/base/templates/root.phtml
+++ b/src/view/base/templates/root.phtml
@@ -20,6 +20,8 @@ $canRequireMagewire = $magewireUtil->canRequireMagewireJsLibrary();
 ?>
 
 <?= $templateUtil->echoCodeComment('start', true) ?>
+<?= $templateUtil->echoCodeComment('default placements', false, 'container') ?>
+<?= $block->getChildHtml('placements') ?>
 <?= $templateUtil->echoCodeComment('global', false, 'container') ?>
 <?= $layoutUtil->getChildHtml($block, 'global', ['require_magewire' => $canRequireMagewire]) ?>
 

--- a/src/view/frontend/layout/magewire_playwright_placements.xml
+++ b/src/view/frontend/layout/magewire_playwright_placements.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd"
+      layout="1column"
+>
+    <body>
+        <referenceContainer name="content">
+            <container name="magewire.playwright.placements"
+                       htmlClass="grid grid-cols-1 gap-x-8 gap-y-16"
+                       htmlId="magewire-playwright-placements"
+                       htmlTag="div"
+            >
+                <block name="magewire.playwright.placements.basic"
+                       template="Magewirephp_Magewire::tests/magewire/playwright/placements/basic.phtml"
+                >
+                    <arguments>
+                        <argument name="magewire" xsi:type="object" shared="false">
+                            Magewirephp\Magewire\Magewire\Playwright\Placements\Basic
+                        </argument>
+                    </arguments>
+                </block>
+            </container>
+        </referenceContainer>
+    </body>
+</page>

--- a/src/view/frontend/templates/tests/magewire/playwright/placements/basic.phtml
+++ b/src/view/frontend/templates/tests/magewire/playwright/placements/basic.phtml
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+?>
+<div>
+    <h2 class="text-lg mb-6 font-bold">
+        Placements
+    </h2>
+
+    <div id="placement-inline-result" data-placement-result="inline">
+        pending
+    </div>
+
+    @script()
+    <script data-placement-script="inline">
+        (() => {
+            const target = document.querySelector('#placement-inline-result');
+
+            if (target) {
+                target.textContent = 'inline';
+            }
+        })();
+    </script>
+    @endscript
+
+    <div id="placement-default-result" data-placement-result="default">
+        pending
+    </div>
+
+    @script(placement: 'default')
+    <script data-placement-script="default">
+        (() => {
+            const target = document.querySelector('#placement-default-result');
+
+            if (target) {
+                target.textContent = 'default';
+            }
+        })();
+    </script>
+    @endscript
+</div>

--- a/tests/Playwright/tests/placements.spec.js
+++ b/tests/Playwright/tests/placements.spec.js
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+const PATH = '/magewire/playwright/placements';
+
+test.describe('Magewire Playwright — Placements', () => {
+    test.beforeEach(async ({ page }) => {
+        const version = Math.floor(Math.random() * 1_000_000);
+        await page.goto(`${PATH}?v=${version}`);
+    });
+
+    test('renders the page with the correct title', async ({ page }) => {
+        await expect(page.locator('[data-ui-id="page-title-wrapper"]'))
+            .toHaveText('Magewire / Playwright / Placements');
+    });
+
+    test('runs inline and placed scripts', async ({ page }) => {
+        await expect(page.locator('[data-placement-result="inline"]')).toHaveText('inline');
+        await expect(page.locator('[data-placement-result="default"]')).toHaveText('default');
+    });
+
+    test('moves placement scripts and links source and placement comments', async ({ page }) => {
+        const html = await page.content();
+        const source = html.match(/<!-- Magewire: Script "([A-Z]+)" transferred to "default"\. -->/);
+
+        expect(source).not.toBeNull();
+        expect(source[1]).toHaveLength(8);
+        expect(html).toContain(`<!-- Magewire: Script placement "${source[1]}". -->`);
+    });
+
+    test('keeps non-placed scripts inline', async ({ page }) => {
+        const html = await page.content();
+        const inlineIndex = html.indexOf('data-placement-script="inline"');
+        const sourceIndex = html.indexOf('Magewire: Script "');
+
+        expect(inlineIndex).toBeGreaterThan(-1);
+        expect(sourceIndex).toBeGreaterThan(-1);
+        expect(inlineIndex).toBeLessThan(sourceIndex);
+    });
+});


### PR DESCRIPTION
## Summary
- add generated PHP literal quoting helpers for compiler directives
- add named script placement support with response and FPC placeholder resolution
- cover script placements with Playwright fixtures and tests
- add Magewire agent skill documentation

## Verification
- php -l over staged placement runtime PHP/PHTML files
- php -l over Playwright PHP/PHTML fixtures