### PR TITLE
fix: add unknown component resolver fallback

### DIFF
--- a/lib/Magewire/Mechanisms/ResolveComponents/ComponentResolver/UnknownResolver.php
+++ b/lib/Magewire/Mechanisms/ResolveComponents/ComponentResolver/UnknownResolver.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolver;
+
+use Magento\Framework\View\Element\AbstractBlock;
+use Magewirephp\Magewire\Exceptions\ComponentNotFoundException;
+use Magewirephp\Magewire\Mechanisms\HandleRequests\ComponentRequestContext;
+use Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentArguments\BlockMagewireArgumentsFactory;
+use Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentArguments\MagewireArguments;
+use Magewirephp\Magewire\Support\Conditions;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Last-resort fallback resolver.
+ *
+ * The {@see \Magewirephp\Magewire\Mechanisms\ResolveComponents\Management\ComponentResolverManager}
+ * falls back to the "unknown" accessor when no registered resolver complies with a block that
+ * nevertheless carries "magewire" data. Before this resolver existed, that fallback threw a cryptic
+ * "No block resolver found for accessor 'unknown'" exception, hiding the real problem: the block was
+ * never recognised by any resolver.
+ *
+ * This resolver exists purely to make that situation explicit. It never auto-selects itself
+ * ({@see complies()} always returns false) and it is never cached ({@see remember()} returns false),
+ * so once the offending block is fixed the correct resolver is picked up again. When reached, it logs
+ * an actionable warning naming the block and then throws a clear exception, because a fallback resolver
+ * genuinely has no way to construct a component.
+ */
+class UnknownResolver extends ComponentResolver
+{
+    protected string $accessor = 'unknown';
+
+    public function __construct(
+        protected Conditions $conditions,
+        protected BlockMagewireArgumentsFactory $blockMagewireArgumentsFactory,
+        protected LoggerInterface $logger
+    ) {
+        parent::__construct($this->conditions);
+    }
+
+    /**
+     * Never comply automatically. This resolver is only ever reached through the manager's explicit
+     * "unknown" fallback accessor, never by iterating registered resolvers.
+     */
+    public function complies(AbstractBlock $block, mixed $magewire = null): bool
+    {
+        return false;
+    }
+
+    /**
+     * @throws ComponentNotFoundException
+     */
+    public function construct(AbstractBlock $block): AbstractBlock
+    {
+        $name = $block->getNameInLayout() ?: $block->getCacheKey();
+
+        $this->logger->warning(sprintf(
+            'Magewire: no component resolver complied for block "%s"; falling back to the "unknown" resolver. '
+            . 'The block carries "magewire" data but no registered resolver recognises it. Check the block\'s '
+            . '"magewire" / "magewire:resolver" arguments, or register a resolver whose complies() matches it.',
+            $name
+        ));
+
+        throw new ComponentNotFoundException(sprintf(
+            'No component resolver could construct the Magewire component for block "%s".',
+            $name
+        ));
+    }
+
+    /**
+     * @throws ComponentNotFoundException
+     */
+    public function reconstruct(ComponentRequestContext $request): AbstractBlock
+    {
+        $name = $request->getSnapshot()->getMemoValue('name') ?? 'unknown';
+
+        $this->logger->warning(sprintf(
+            'Magewire: subsequent request resolved to the "unknown" fallback resolver for component "%s". '
+            . 'The originating resolver could not be determined, so the component cannot be reconstructed.',
+            $name
+        ));
+
+        throw new ComponentNotFoundException(sprintf(
+            'No component resolver could reconstruct the Magewire component "%s".',
+            $name
+        ));
+    }
+
+    public function arguments(): MagewireArguments
+    {
+        return $this->arguments ??= $this->blockMagewireArgumentsFactory->create();
+    }
+
+    /**
+     * Never cache the fallback, so the correct resolver is re-evaluated once the block is fixed.
+     */
+    public function remember(): bool
+    {
+        return false;
+    }
+}

--- a/lib/Magewire/Mechanisms/ResolveComponents/ComponentResolver/UnknownResolver.php
+++ b/lib/Magewire/Mechanisms/ResolveComponents/ComponentResolver/UnknownResolver.php
@@ -69,10 +69,7 @@ class UnknownResolver extends ComponentResolver
             $name
         ));
 
-        throw new ComponentNotFoundException(sprintf(
-            'No component resolver could construct the Magewire component for block "%s".',
-            $name
-        ));
+        throw new ComponentNotFoundException(sprintf('No component resolver could construct the Magewire component for block "%s".', $name));
     }
 
     /**
@@ -88,10 +85,7 @@ class UnknownResolver extends ComponentResolver
             $name
         ));
 
-        throw new ComponentNotFoundException(sprintf(
-            'No component resolver could reconstruct the Magewire component "%s".',
-            $name
-        ));
+        throw new ComponentNotFoundException(sprintf('No component resolver could reconstruct the Magewire component "%s".', $name));
     }
 
     public function arguments(): MagewireArguments

--- a/src/etc/adminhtml/di.xml
+++ b/src/etc/adminhtml/di.xml
@@ -437,6 +437,11 @@
                 <item name="layout" xsi:type="object" sortOrder="99900">
                     Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolver\LayoutResolver
                 </item>
+
+                <!-- Last-resort fallback. Never complies on its own; only reached via the "unknown" accessor. -->
+                <item name="unknown" xsi:type="object" sortOrder="100000">
+                    Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolver\UnknownResolver
+                </item>
             </argument>
         </arguments>
     </type>

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -491,6 +491,9 @@
                 <item name="flux" xsi:type="object">Magewirephp\Magewire\Features\SupportMagewireFlakes\Mechanisms\ResolveComponent\ComponentResolver\FluxResolver</item>
 
                 <item name="layout" xsi:type="object" sortOrder="99900">Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolver\LayoutResolver</item>
+
+                <!-- Last-resort fallback. Never complies on its own; only reached via the "unknown" accessor. -->
+                <item name="unknown" xsi:type="object" sortOrder="100000">Magewirephp\Magewire\Mechanisms\ResolveComponents\ComponentResolver\UnknownResolver</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
## Problem

`ComponentResolverManager::resolve()` falls back to the `"unknown"` accessor when no registered resolver `complies()` with a block that still carries `magewire` data ([`ComponentResolverManager.php:101`](../blob/main/lib/Magewire/Mechanisms/ResolveComponents/Management/ComponentResolverManager.php#L101)). No resolver was ever bound to that accessor, so `getResolverClass()` threw:

```
ComponentResolverNotFoundException: No block resolver found for accessor "unknown"
```

That message hid the real cause (a block no resolver recognises) and got logged as `critical`.

## Fix

Add `UnknownResolver` as an explicit last-resort fallback:

- `complies()` always returns `false` — never auto-selected; only reached via the manager's explicit `"unknown"` accessor.
- `remember()` returns `false` — never cached, so the correct resolver is re-evaluated once the offending block is fixed.
- `construct()` / `reconstruct()` log an actionable **warning** naming the block (with a hint to check `magewire` / `magewire:resolver` arguments or register a complying resolver), then throw a clear `ComponentNotFoundException` — a fallback genuinely cannot build a component, so it fails loud but informative instead of cryptic.

Registered under the `"unknown"` accessor in both `frontend` and `adminhtml` DI.

## Result

Instead of the misleading `No block resolver found for accessor "unknown"`, developers now get a warning explaining that no resolver complied for the named block and that Magewire fell back to `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)