### PR TITLE
ci: enable Magewire debug toggle for Playwright + retry flaky specs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -204,6 +204,11 @@ jobs:
           php bin/magento module:enable Magewirephp_MagewireHyvaTheme || true
           php bin/magento setup:upgrade --no-interaction
 
+          # Magewire's debug toggle (magewire/debug/enable) drives config('app.debug').
+          # The multiple-root-element detection only runs when it is on, so the
+          # multiple-roots specs need it enabled to see the inline exception block.
+          php bin/magento config:set magewire/debug/enable 1
+
           # Activate the Hyvä frontend theme by its registered code.
           THEME_ID=$(mysql -h 127.0.0.1 -uroot -proot magento -N -B \
             -e "SELECT theme_id FROM theme WHERE code='Hyva/default' AND area='frontend' LIMIT 1")

--- a/tests/Playwright/playwright.config.js
+++ b/tests/Playwright/playwright.config.js
@@ -5,6 +5,10 @@ import process from 'process';
 export default defineConfig({
     testDir: '.',
     fullyParallel: true,
+    // Magewire specs drive live AJAX round-trips against a Magento store; a
+    // component that is mid-hydrate on the first hit reliably settles on a
+    // retry. Retry more aggressively on CI, once locally.
+    retries: process.env.CI ? 2 : 1,
     reporter: [['list']],
     use: {
         baseURL: process.env.BASE_URL.replace(/^\/+|\/+$/g, ''),


### PR DESCRIPTION
## What

Two CI-only changes for the Mage-OS + Hyvä Playwright workflow:

- **`playwright.yml`** — `bin/magento config:set magewire/debug/enable 1` during store setup.
- **`playwright.config.js`** — `retries: process.env.CI ? 2 : 1`.

## Why

The **`multiple-roots` specs fail** on `main` ("element not found"). Multiple-root-element detection only runs when Magewire's debug toggle (`magewire/debug/enable`, which backs `config('app.debug')`) is enabled — otherwise the inline exception block those specs assert on never renders. The workflow never turned it on.

The retries guard the live-AJAX specs, which can catch a component mid-hydrate on the first hit.

## Context

Extracted from #246. That PR's directive fix (`FunctionDirective` → `Directive`, `FUNCTION_ARGUMENTS`) is **superseded** by #248 + #249 (`EXPRESSION_ARGUMENTS`) already on `main`, and would conflict/regress if merged. These two CI lines are the only still-relevant part, rebased onto `main`. Closing #246 in favour of this.

No application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)