### PR TITLE
feat: pluggable handler for multiple-root-element detection

### DIFF
--- a/dist/Features/SupportMultipleRootElementDetection/SupportMultipleRootElementDetection.php
+++ b/dist/Features/SupportMultipleRootElementDetection/SupportMultipleRootElementDetection.php
@@ -12,6 +12,8 @@ namespace Magewirephp\Magewire\Features\SupportMultipleRootElementDetection;
 use function Magewirephp\Magewire\on;
 use function Magewirephp\Magewire\config;
 use Magewirephp\Magewire\ComponentHook;
+use Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\Api\MultipleRootElementDetectionHandlerInterface;
+use Magewirephp\Magewire\Support\Factory;
 class SupportMultipleRootElementDetection extends ComponentHook
 {
     // Redeclared verbatim from upstream so this file's `config`/`on` function imports
@@ -24,16 +26,25 @@ class SupportMultipleRootElementDetection extends ComponentHook
                 return;
             }
             return function ($html) use ($component) {
-                (new static())->warnAgainstMoreThanOneRootElement($component, $html);
+                // Return the (possibly handler-modified) HTML so the EventBus finisher forwards it.
+                return (new static())->warnAgainstMoreThanOneRootElement($component, $html);
             };
         });
     }
+    /**
+     * On a single root element everything is fine. Otherwise the detection handler decides what
+     * happens: the default throws (MultipleRootElementsDetectedException), but the handler is a DI
+     * preference, so a project can swap in its own (log, browser console, ...) and return the HTML
+     * to forward down the pipeline.
+     */
     function warnAgainstMoreThanOneRootElement($component, $html)
     {
         $count = $this->getRootElementCount($html);
-        if ($count > 1) {
-            throw new MultipleRootElementsDetectedException($component);
+        if ($count <= 1) {
+            return $html;
         }
+        return Factory::get(MultipleRootElementDetectionHandlerInterface::class)
+            ->handle($component, $html, $count);
     }
     /**
      * Counts top-level (depth 0) element openings without a full DOM parse.

--- a/lib/Magewire/Features/SupportMultipleRootElementDetection/Api/MultipleRootElementDetectionHandlerInterface.php
+++ b/lib/Magewire/Features/SupportMultipleRootElementDetection/Api/MultipleRootElementDetectionHandlerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\Api;
+
+use Magewirephp\Magewire\Component;
+
+/**
+ * Strategy for reacting to a Magewire component that rendered more than one root element.
+ *
+ * Implementations decide what happens: throw (the default), warn in the browser, log, etc.
+ * Register one by overriding the DI preference for this interface.
+ *
+ * @api
+ */
+interface MultipleRootElementDetectionHandlerInterface
+{
+    /**
+     * React to the detected violation and return the HTML to forward down the pipeline.
+     *
+     * The returned string replaces the component HTML (see EventBus finisher), so a
+     * handler may append markup (e.g. an inline console script). Throwing is allowed and
+     * aborts the render.
+     */
+    public function handle(Component $component, string $html, int $rootCount): string;
+}

--- a/lib/Magewire/Features/SupportMultipleRootElementDetection/Handler/ThrowExceptionHandler.php
+++ b/lib/Magewire/Features/SupportMultipleRootElementDetection/Handler/ThrowExceptionHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\Handler;
+
+use Magewirephp\Magewire\Component;
+use Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\Api\MultipleRootElementDetectionHandlerInterface;
+use Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\MultipleRootElementsDetectedException;
+
+/**
+ * Default behavior: throw, aborting the render. Preserves the original detection contract.
+ */
+class ThrowExceptionHandler implements MultipleRootElementDetectionHandlerInterface
+{
+    public function handle(Component $component, string $html, int $rootCount): string
+    {
+        throw new MultipleRootElementsDetectedException($component);
+    }
+}

--- a/portman/Livewire/Features/SupportMultipleRootElementDetection/SupportMultipleRootElementDetection.php
+++ b/portman/Livewire/Features/SupportMultipleRootElementDetection/SupportMultipleRootElementDetection.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Magewirephp\Magewire\Features\SupportMultipleRootElementDetection;
 
+use Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\Api\MultipleRootElementDetectionHandlerInterface;
+use Magewirephp\Magewire\Support\Factory;
+
 use function Magewirephp\Magewire\on;
 use function Magewirephp\Magewire\config;
 
@@ -30,9 +33,28 @@ class SupportMultipleRootElementDetection extends \Livewire\Features\SupportMult
             }
 
             return function ($html) use ($component) {
-                (new static())->warnAgainstMoreThanOneRootElement($component, $html);
+                // Return the (possibly handler-modified) HTML so the EventBus finisher forwards it.
+                return (new static())->warnAgainstMoreThanOneRootElement($component, $html);
             };
         });
+    }
+
+    /**
+     * On a single root element everything is fine. Otherwise the detection handler decides what
+     * happens: the default throws (MultipleRootElementsDetectedException), but the handler is a DI
+     * preference, so a project can swap in its own (log, browser console, ...) and return the HTML
+     * to forward down the pipeline.
+     */
+    function warnAgainstMoreThanOneRootElement($component, $html)
+    {
+        $count = $this->getRootElementCount($html);
+
+        if ($count <= 1) {
+            return $html;
+        }
+
+        return Factory::get(MultipleRootElementDetectionHandlerInterface::class)
+            ->handle($component, $html, $count);
     }
 
     /**

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -8,6 +8,15 @@
     />
 
     <!--
+        Default reaction when a component renders more than one root element: throw. This is the
+        extension point — a project can override this preference with its own handler (log, browser
+        console, ...) implementing MultipleRootElementDetectionHandlerInterface.
+    -->
+    <preference for="Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\Api\MultipleRootElementDetectionHandlerInterface"
+                type="Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\Handler\ThrowExceptionHandler"
+    />
+
+    <!--
         Bindings: Frontend Proxies
 
         DOC: Magento Proxies optimize performance by delaying the instantiation of resource-intensive objects until they are needed.


### PR DESCRIPTION
## What

Keeps the current behaviour — a component with more than one root element throws `MultipleRootElementsDetectedException` (debug-gated, Livewire parity) — but makes the *reaction* a swappable strategy so projects can extend it without patching core.

- `MultipleRootElementDetectionHandlerInterface` — the extension point (`handle($component, $html, $rootCount): string`).
- `ThrowExceptionHandler` — the default, registered via a DI `<preference>`. Preserves today's throw.
- `SupportMultipleRootElementDetection` now delegates to the injected handler and forwards the (possibly handler-modified) HTML, instead of throwing inline. Debug gate unchanged.

Override the preference to plug in your own handler (log, browser console, silent, …):

```xml
<preference for="Magewirephp\Magewire\Features\SupportMultipleRootElementDetection\Api\MultipleRootElementDetectionHandlerInterface"
            type="Vendor\Module\MyHandler"/>
```

## Why not #241

#241 took this much further — a config-driven handler pool, a `DetectionBehavior` source (exception/console/log/off), four shipped handlers, `config.xml` defaults and admin config UI. That's more surface than this needs, and it dropped the debug gate. This PR is the scaled-down version: **just the exception (like Livewire) plus the interface for extensibility**. Closing #241 in favour of this.

## Notes

- `dist/` + `portman/` augmentation both updated (the augmentation now overrides `warnAgainstMoreThanOneRootElement`, so a portman regen reproduces the change).
- No behaviour config, no pool, no admin UI.

## Tests

Full Playwright suite **35/35** locally, including `multiple-roots` (invalid → inline exception block via the default handler; valid → mounts untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)