### PR TITLE
chore: fix release-please 3.3.0 boundary after history rewrite

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "include-v-in-tag": false,
+  "last-release-sha": "845e3b5db0a068bcfd971fed87de604273ca6f36",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Problem

PR #240 (`chore(main): release 3.3.0`) lists **every feature ever written in Magewire V3**, not just what landed since 3.2.0.

Cause: the recent history rewrite (removing a file from the entire git history) re-wrote every commit SHA. The `3.2.0` tag still points to its **old** SHA (`a7e33a6…`), which is no longer an ancestor of `main`. release-please can't find the 3.2.0 boundary from that orphaned tag, so it walks the whole history and attributes all of it to 3.3.0.

## Fix

Add release-please's own `last-release-sha` option (schema: *"For any release, only consider as far back as this commit SHA"*), pinned to `845e3b5` — the `chore(main): release 3.2.0 (#233)` commit in the **current** history:

```json
"last-release-sha": "845e3b5db0a068bcfd971fed87de604273ca6f36"
```

release-please then only considers the 15 commits after it, so 3.3.0 lists exactly what shipped since 3.2.0 (#242, #244, #245, #248, #249, #250, the compile:clear command, …).

**No tag was moved** — the published `3.2.0` tag is left untouched; this is a config-only, release-please-native fix.

Once this merges, release-please regenerates #240 with the correct changelog. The line can be removed after 3.3.0 is tagged in the rewritten history (that tag will then be a valid in-history boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)