### PR TITLE
fix(deps): widen illuminate/support to span v10–v13

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,16 @@ name: 'Playwright (Mage-OS + Hyvä)'
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'lib/**'
+      - 'dist/**'
+      - 'composer.json'
+      - 'tests/Playwright/**'
+      - '.github/workflows/playwright.yml'
   pull_request:
     branches:
       - main

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,7 @@ on:
       - 'src/**'
       - 'lib/**'
       - 'dist/**'
+      - 'composer.json'
       - 'tests/Playwright/**'
       - '.github/workflows/playwright.yml'
 
@@ -36,21 +37,33 @@ concurrency:
 jobs:
 
   playwright:
-    name: 'Mage-OS ${{ matrix.mage_os }} / PHP ${{ matrix.php }}'
+    name: 'Mage-OS ${{ matrix.mage_os }} / PHP ${{ matrix.php }} / illuminate ${{ matrix.illuminate || ''host'' }}'
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Latest Mage-OS distribution.
+          # Latest Mage-OS, host-native illuminate. Mage-OS 3.x ships a spatie/ignition
+          # tree pinned at illuminate ^13, so leaving `illuminate` empty resolves the
+          # suite at v13 — the "fit into the host" path the widened illuminate/support
+          # constraint (^10.48 || ^11 || ^12 || ^13) enables. No forced downgrade.
           - mage_os: '3.1.0'
             php: '8.4'
+            illuminate: ''
+          # Same distribution, illuminate pinned to the legacy floor. Proves the old
+          # v10 path still resolves and runs — this drags nesbot/carbon down to 2.x and
+          # symfony/translation to 6.4 (spatie/flare accepts the downgraded tree).
+          - mage_os: '3.1.0'
+            php: '8.4'
+            illuminate: '^10.48'
           # Oldest documented Mage-OS distribution (Magento 2.4.6 base). Its composer
           # constraint is ~8.1||~8.2, so PHP 8.3 would fail the platform check — 8.2 is
-          # the floor that also satisfies this module's php>=8.2 requirement.
+          # the floor that also satisfies this module's php>=8.2 requirement. Left on
+          # the host-native illuminate that this older distribution ships.
           - mage_os: '1.0.5'
             php: '8.2'
+            illuminate: ''
 
     env:
       MAGENTO_DIR: ${{ github.workspace }}/magento
@@ -169,18 +182,35 @@ jobs:
 
           # Add this PR's module (pinned to 3.999.0), the Hyvä default theme, and the
           # Magewire-Hyvä compat layer to composer.json WITHOUT resolving yet.
+          #
+          # When matrix.illuminate is set, also pin illuminate/support to that major so
+          # this row exercises a specific end of the module's widened constraint range
+          # (^10.48 || ^11 || ^12 || ^13). Empty means "let the resolver keep whatever
+          # illuminate the host platform pins" — on Mage-OS 3.x that is the spatie/
+          # ignition tree's v13.
+          ILLUMINATE_PIN=""
+          if [ -n "${{ matrix.illuminate }}" ]; then
+            ILLUMINATE_PIN="illuminate/support:${{ matrix.illuminate }}"
+          fi
           composer require --no-update --no-interaction \
             "magewirephp/magewire:3.999.0" \
             hyva-themes/magento2-default-theme \
-            magewirephp/magewire-hyva-theme
+            magewirephp/magewire-hyva-theme \
+            $ILLUMINATE_PIN
 
-          # One full re-resolve. Mage-OS 3.x ships a runtime spatie/ignition tree
+          # One full re-resolve (-W updates dependencies of the just-required packages
+          # too). Mage-OS 3.x ships a runtime spatie/ignition tree
           # (swissup/module-ignition -> spatie/ignition -> spatie/flare ->
-          # illuminate/pipeline) whose pipeline was locked at v13 (needs illuminate ^13).
-          # A scoped update leaves that sibling locked; a full update lets this module's
-          # hard illuminate/support ^10.48 pull the whole illuminate tree — pipeline
-          # included — down to 10.x (spatie/flare accepts pipeline ^10).
+          # illuminate/pipeline) that resolves at illuminate v13. With no illuminate pin
+          # the whole suite stays at v13 (Magewire's widened constraint accepts it).
+          # When pinned to ^10.48 the resolver drags the tree — pipeline included — down
+          # to 10.x (spatie/flare accepts pipeline ^10), dragging carbon->2 and
+          # symfony/translation->6.4 with it. Either way the suite must resolve and run.
           composer update --no-dev --no-interaction --no-progress -W
+
+          # Record what illuminate actually resolved to, so the log shows which end of
+          # the range this row exercised (and catches a silent pin miss).
+          composer show illuminate/support | grep -i '^versions' || true
 
       - name: Install Mage-OS
         working-directory: ${{ env.MAGENTO_DIR }}
@@ -294,7 +324,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-results-mageos-${{ matrix.mage_os }}
+          name: playwright-results-mageos-${{ matrix.mage_os }}-illuminate-${{ matrix.illuminate || 'host' }}
           path: |
             ${{ env.MODULE_DIR }}/tests/Playwright/test-results
             ${{ github.workspace }}/phpserver.log

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Total Downloads](http://poser.pugx.org/magewirephp/magewire/downloads)](https://packagist.org/packages/magewirephp/magewire)
 [![License](http://poser.pugx.org/magewirephp/magewire/license)](https://packagist.org/packages/magewirephp/magewire)
 [![Mago](https://github.com/magewirephp/magewire/actions/workflows/mago.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/mago.yml)
+[![Playwright tests](https://github.com/magewirephp/magewire/actions/workflows/playwright.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/playwright.yml?query=branch%3Amain)
 
 MagewirePHP brings the power of reactive, server-driven UI development to Magento 2—without writing JavaScript.
 Inspired by Laravel Livewire, MagewirePHP lets you build dynamic, interactive frontend components using only PHP,

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=8.2",
         "magento/framework": "*",
-        "illuminate/support": "^10.48",
+        "illuminate/support": "^10.48 || ^11.0 || ^12.0 || ^13.0",
         "magewirephp/validation": "^1.0"
     },
     "require-dev": {

--- a/dist/Mechanisms/HandleComponents/HandleComponents.php
+++ b/dist/Mechanisms/HandleComponents/HandleComponents.php
@@ -32,7 +32,16 @@ use Magewirephp\Magewire\Exceptions\PublicPropertyNotFoundException;
 use Illuminate\Support\Facades\View;
 class HandleComponents extends Mechanism
 {
-    protected $propertySynthesizers = [Synthesizers\CarbonSynth::class, Synthesizers\CollectionSynth::class, Synthesizers\StringableSynth::class, Synthesizers\EnumSynth::class, Synthesizers\StdClassSynth::class, Synthesizers\ArraySynth::class, Synthesizers\IntSynth::class, Synthesizers\FloatSynth::class];
+    /**
+     * The active synthesizer list is injected via DI (see the frontend and
+     * adminhtml di.xml) and assigned in the constructor below. Livewire's
+     * upstream default referenced
+     * Carbon/Collection/Stringable synths that Magewire does not ship; declaring
+     * an empty default here keeps them out of the generated dist output.
+     *
+     * @var array
+     */
+    protected $propertySynthesizers = [];
     public static $renderStack = [];
     public static $componentStack = [];
     public function registerPropertySynthesizer($synth)

--- a/portman/Livewire/Mechanisms/HandleComponents/HandleComponents.php
+++ b/portman/Livewire/Mechanisms/HandleComponents/HandleComponents.php
@@ -29,6 +29,17 @@ use Magewirephp\Magewire\Exceptions\MethodNotFoundException;
 
 class HandleComponents extends \Livewire\Mechanisms\HandleComponents\HandleComponents
 {
+    /**
+     * The active synthesizer list is injected via DI (see the frontend and
+     * adminhtml di.xml) and assigned in the constructor below. Livewire's
+     * upstream default referenced
+     * Carbon/Collection/Stringable synths that Magewire does not ship; declaring
+     * an empty default here keeps them out of the generated dist output.
+     *
+     * @var array
+     */
+    protected $propertySynthesizers = [];
+
     public function __construct(
         private readonly ComponentContextFactory $componentContextFactory,
         private readonly Checksum $checksum,


### PR DESCRIPTION
## Why

Magewire pinned `illuminate/support` to `^10.48`. Because Magewire is a Magento module — a *guest* on the host platform — that hard pin forced the entire `illuminate/*` suite (and `nesbot/carbon`, `symfony/translation`) **down** to v10 on any platform that already shipped something newer.

On Mage-OS 3.x this collides head-on with `swissup/module-ignition` (a runtime dependency of `mage-os/product-community-edition` itself), whose Spatie Ignition chain resolves the illuminate tree at **v13**. The pin made Magewire the reason a host platform had to downgrade its own dependencies — backwards for a guest module, and fragile for every other consumer of illuminate v13.

## What

Widen the constraint so Magewire resolves against **whatever illuminate the host pins**, instead of dragging it down:

```diff
- "illuminate/support": "^10.48",
+ "illuminate/support": "^10.48 || ^11.0 || ^12.0 || ^13.0",
```

This is safe because Magewire's real illuminate surface is tiny and stable across majors:

- Hand-written code (`src` + `lib/Magewire`) touches only `Str` / `Arr` (helpers, `MagewireArguments`, `DataCollection`) plus `Collection` and `MessageBag`.
- Every `Str`/`Arr` method used — `camel, snake, kebab, studly, of, before, contains, collapse, accessible, exists, get, wrap, except, prependKeysWith` — is signature-stable v10 → v13.
- Everything heavier (`Http`, `Routing`, `Auth`, `Eloquent`, `Foundation`) lives in the ported `dist/` and is unreachable in Magento.

### The Carbon dependency was never real

The one thing that *looked* like a hard Carbon (illuminate 11+ → Carbon 3) dependency was `CarbonSynth` in `HandleComponents`' default `$propertySynthesizers`. It is dead:

- `Synthesizers\CarbonSynth::class` is a `::class` string — never autoloaded.
- The class does not even exist in the repo.
- The constructor **overwrites** the property with the DI-injected list, which is `DataObject, Array, Enum, Float, Int, StdClass` — no Carbon.

So it never loaded and never ran. This PR removes it (and the equally-phantom `CollectionSynth` / `StringableSynth`) from the default via the portman augmentation, so the generated `dist/` no longer names classes that don't exist and no longer *looks* like it depends on `nesbot/carbon`. **Behaviour is unchanged** — the active synthesizer list stays DI-driven.

## Proof, not just reasoning

The Mage-OS Playwright workflow gains an `illuminate` matrix axis so both ends of the widened range are exercised end-to-end:

| Mage-OS | PHP | illuminate | Exercises |
|---------|-----|-----------|-----------|
| 3.1.0 | 8.4 | host | resolves the spatie/ignition tree's native **v13** — the fit-into-host path |
| 3.1.0 | 8.4 | `^10.48` | forces the legacy **v10** downgrade (carbon 2.x, symfony/translation 6.4) |
| 1.0.5 | 8.2 | host | oldest documented distribution, unchanged |

When `matrix.illuminate` is set it is pinned into the root `require` before the full `composer update -W`; empty lets the resolver keep the host's illuminate. The resolved version is logged so a silent pin miss is visible.

## Downstream effect

Consumers (e.g. Hyvä Checkout 1.4 moving from Magewire 1.x to v3) no longer need the scoped `spatie/* + nesbot/carbon + symfony/translation` downgrade dance in their root `composer update`. A plain require resolves against the host's illuminate.

## Commits

1. `fix(deps)` — widen `illuminate/support` to span v10–v13
2. `refactor(synthesizers)` — drop phantom Carbon/Collection/Stringable defaults
3. `ci` — exercise illuminate v10 and v13 across the Playwright matrix
