### PR TITLE
accept Phrase messages in SilentException constructor

### DIFF
--- a/src/Exceptions/SilentException.php
+++ b/src/Exceptions/SilentException.php
@@ -12,7 +12,16 @@ declare(strict_types=1);
 namespace Magewirephp\Magewire\Exceptions;
 
 use Exception;
+use Magento\Framework\Phrase;
+use Throwable;
 
 class SilentException extends Exception
 {
+    public function __construct(
+        string|Phrase $message = '',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct((string) $message, $code, $previous);
+    }
 }

--- a/src/Exceptions/SilentException.php
+++ b/src/Exceptions/SilentException.php
@@ -20,7 +20,7 @@ class SilentException extends Exception
     public function __construct(
         string|Phrase $message = '',
         int $code = 0,
-        ?Throwable $previous = null
+        Throwable|null $previous = null
     ) {
         parent::__construct((string) $message, $code, $previous);
     }


### PR DESCRIPTION
`Form::validate()` throws `ValidationException`/`AcceptableException` with a `Magento\Framework\Phrase` returned from `__()`. These exceptions ultimately extend PHP's native `\Exception`, whose constructor expects a string message. Under `declare(strict_types=1)`, passing a `Phrase` results in a `TypeError`.

Fix this by widening `SilentException::__construct()` to accept `string|Phrase` and casting to a string once in the constructor. This resolves the issue for the entire `AcceptableException`/`ValidationException` hierarchy at the root, rather than requiring casts at every call site.