### PR TITLE
chore: define release-please changelog-sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,19 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "php",
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "chore", "section": "Miscellaneous Chores" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Adds an explicit `changelog-sections` map to the release-please package config.

## Why

The default config hid `refactor:` commits and lumped everything else into narrow sections, so the auto-generated 3.3.0 notes dropped real changes (e.g. the Feature/Mechanism refactors). This makes future release notes match the curated 3.3.0 format without hand-editing the PR body / `CHANGELOG.md`.

## What

- `feat` → Features
- `fix` → Bug Fixes
- `perf` → Performance Improvements
- `refactor` → **Code Refactoring** (newly surfaced)
- `chore` → Miscellaneous Chores
- `docs` / `ci` / `test` / `build` / `style` → hidden

## Merge order

⚠️ Merge the **3.3.0 release PR (#240) first**, then this one. Merging to `main` re-runs release-please and regenerates the release branch — landing this before #240 would overwrite the curated 3.3.0 notes.

Does not fix non-prefixed commit subjects (those still fall through) — PR titles must use a conventional prefix to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)