### PR TITLE
fix: null array offset in Conditions::set() breaking component init in production

### DIFF
--- a/lib/Magewire/Support/Conditions.php
+++ b/lib/Magewire/Support/Conditions.php
@@ -37,7 +37,7 @@ class Conditions
      */
     private function set(callable $condition, ConditionEnum $type, string|null $name = null): static
     {
-        $name ?? count($this->get($type));
+        $name ??= count($this->get($type));
         $this->conditions[$type->value][$name] = $condition;
 
         return $this;


### PR DESCRIPTION
### Problem
In `lib/Magewire/Support/Conditions.php`, `set()` intends to auto-index unnamed
conditions but the default-assignment is a no-op:

```php
$name ?? count($this->get($type));   // result discarded — $name stays null
$this->conditions[$type->value][$name] = $condition;