### PR TITLE
ci: add production build check (setup:di:compile)

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -1,17 +1,16 @@
 name: 'Production build'
 
-# Verifies the module survives a Magento production BUILD phase — the two commands a
-# real deploy runs before anything touches a database:
+# Verifies the module survives a Magento production build — the compile step a real
+# deploy runs before serving traffic:
 #
 #   bin/magento setup:di:compile
-#   bin/magento setup:static-content:deploy -f
 #
-# This mirrors the Adobe Commerce Cloud / Mage-OS build step, which runs WITHOUT a
-# database, env.php, or a search engine. It is exactly this module's risk surface:
-# di:compile fails on broken di.xml / uncompilable classes / bad proxies-factories,
-# and static-content:deploy fails on invalid view files (LESS, requirejs-config,
-# template registration). No secrets, no services — fast and deterministic, so a green
-# badge means a tag can ship without manually build-testing first.
+# This is the module's core production risk surface: di:compile fails on broken di.xml,
+# uncompilable classes, or bad proxies/factories. It runs WITHOUT a database, env.php,
+# or a search engine (the Adobe Commerce Cloud / Mage-OS build phase) — module:enable
+# writes the module list to config.php, which is all di:compile needs. No secrets, no
+# services: fast and deterministic, so a green badge means a tag can ship without a
+# manual local compile test.
 
 on:
   workflow_dispatch:
@@ -126,10 +125,3 @@ jobs:
       - name: setup:di:compile
         working-directory: ${{ env.MAGENTO_DIR }}
         run: php bin/magento setup:di:compile --no-interaction
-
-      - name: setup:static-content:deploy
-        working-directory: ${{ env.MAGENTO_DIR }}
-        run: |
-          # -f forces deployment outside production mode (the build phase runs in
-          # default mode). Deploys every registered theme/area in en_US.
-          php bin/magento setup:static-content:deploy -f --no-interaction en_US

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -1,0 +1,135 @@
+name: 'Production build'
+
+# Verifies the module survives a Magento production BUILD phase — the two commands a
+# real deploy runs before anything touches a database:
+#
+#   bin/magento setup:di:compile
+#   bin/magento setup:static-content:deploy -f
+#
+# This mirrors the Adobe Commerce Cloud / Mage-OS build step, which runs WITHOUT a
+# database, env.php, or a search engine. It is exactly this module's risk surface:
+# di:compile fails on broken di.xml / uncompilable classes / bad proxies-factories,
+# and static-content:deploy fails on invalid view files (LESS, requirejs-config,
+# template registration). No secrets, no services — fast and deterministic, so a green
+# badge means a tag can ship without manually build-testing first.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'lib/**'
+      - 'dist/**'
+      - 'composer.json'
+      - '.github/workflows/production-build.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'lib/**'
+      - 'dist/**'
+      - 'composer.json'
+      - '.github/workflows/production-build.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  production-build:
+    name: 'Mage-OS ${{ matrix.mage_os }} / PHP ${{ matrix.php }}'
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mage_os: '3.1.0'
+            php: '8.4'
+
+    env:
+      MAGENTO_DIR: ${{ github.workspace }}/magento
+      MODULE_DIR: ${{ github.workspace }}/magewire-src
+      COMPOSER_MEMORY_LIMIT: '-1'
+
+    steps:
+      - name: Checkout module (the PR code)
+        uses: actions/checkout@v7
+        with:
+          path: magewire-src
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: bcmath, ctype, curl, dom, gd, hash, iconv, intl, mbstring, openssl, pdo_mysql, simplexml, soap, sockets, xsl, zip, fileinfo
+          tools: composer:v2
+          ini-values: memory_limit=-1
+        env:
+          COMPOSER_TOKEN: ${{ github.token }}
+
+      - name: Create Mage-OS project
+        run: |
+          composer create-project \
+            --repository-url=https://repo.mage-os.org/ \
+            --no-install \
+            "mage-os/project-community-edition:${{ matrix.mage_os }}" \
+            "$MAGENTO_DIR"
+
+      - name: Configure Composer repositories & auth
+        working-directory: ${{ env.MAGENTO_DIR }}
+        run: |
+          # Allow dev versions so the path-based module (this PR) can be required.
+          composer config minimum-stability dev
+          composer config prefer-stable true
+
+          # We override magewirephp/magewire with this PR's branch via a path repo. The
+          # version-audit plugin reads the public dev-main as "higher" than the branch
+          # and aborts as if it were dependency confusion. Mage-OS ships its own fork of
+          # the plugin too; disable both for this CI-only install.
+          composer config allow-plugins.mage-os/composer-dependency-version-audit-plugin false
+          composer config allow-plugins.magento/composer-dependency-version-audit-plugin false
+
+          # Path repository pointing at the checked-out module. symlink:false so composer
+          # COPIES it into magento/vendor/ — a symlink leaves the sources outside the
+          # Magento root and its filesystem validator rejects paths that resolve outside.
+          composer config repositories.magewire-src \
+            "{\"type\":\"path\",\"url\":\"$MODULE_DIR\",\"options\":{\"symlink\":false}}"
+
+          # actions/checkout leaves a detached HEAD, so composer would derive the path
+          # repo version as dev-<sha> and no constraint would match. Pin an explicit high
+          # version instead — deterministic (CI-only; not committed).
+          composer --working-dir="$MODULE_DIR" config version 3.999.0
+
+      - name: Install Mage-OS + module (production deps only)
+        working-directory: ${{ env.MAGENTO_DIR }}
+        run: |
+          composer install --no-dev --no-interaction --no-progress
+          composer require --no-update --no-interaction "magewirephp/magewire:3.999.0"
+          composer update --no-dev --no-interaction --no-progress -W
+
+      - name: Enable all modules (writes app/etc/config.php)
+        working-directory: ${{ env.MAGENTO_DIR }}
+        run: |
+          # module:enable works pre-install: it only writes the module list to
+          # config.php. No database, no env.php — the build phase never has them.
+          php bin/magento module:enable --all --no-interaction
+          php bin/magento module:status Magewirephp_Magewire
+
+      - name: setup:di:compile
+        working-directory: ${{ env.MAGENTO_DIR }}
+        run: php bin/magento setup:di:compile --no-interaction
+
+      - name: setup:static-content:deploy
+        working-directory: ${{ env.MAGENTO_DIR }}
+        run: |
+          # -f forces deployment outside production mode (the build phase runs in
+          # default mode). Deploys every registered theme/area in en_US.
+          php bin/magento setup:static-content:deploy -f --no-interaction en_US

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Total Downloads](http://poser.pugx.org/magewirephp/magewire/downloads)](https://packagist.org/packages/magewirephp/magewire)
 [![License](http://poser.pugx.org/magewirephp/magewire/license)](https://packagist.org/packages/magewirephp/magewire)
 [![Mago](https://github.com/magewirephp/magewire/actions/workflows/mago.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/mago.yml)
+[![Production build](https://github.com/magewirephp/magewire/actions/workflows/production-build.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/production-build.yml?query=branch%3Amain)
 [![Playwright tests](https://github.com/magewirephp/magewire/actions/workflows/playwright.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/playwright.yml?query=branch%3Amain)
 
 MagewirePHP brings the power of reactive, server-driven UI development to Magento 2—without writing JavaScript.

--- a/lib/Magewire/Support/Conditions.php
+++ b/lib/Magewire/Support/Conditions.php
@@ -15,7 +15,6 @@ use Magewirephp\Magewire\Support\Conditions\ConditionEnum;
 
 /**
  * @mago-expect lint:too-many-methods
- * @mago-expect lint:cyclomatic-complexity
  */
 class Conditions
 {


### PR DESCRIPTION
## What

Adds a DB-less CI workflow that runs the compile step a Magento production build runs before serving traffic:

```
bin/magento setup:di:compile
```

The module is installed into a fresh Mage-OS project via a path repo (same pattern as `playwright.yml`), then `module:enable --all` writes `config.php` and `di:compile` runs. **No MySQL, OpenSearch, env.php, or secrets** — this mirrors the Adobe Commerce Cloud / Mage-OS *build phase*.

## Why

`di:compile` is the module's core production risk surface — it fails on broken `di.xml`, uncompilable classes, or bad proxies/factories. Any of those means a tag cannot deploy to a production store.

A green **Production build** badge on the README turns "can this tag ship safely?" into a glance instead of a manual local compile test.

### Why not static-content:deploy too?

The first cut ran it, but on Mage-OS 3.x `static-content:deploy`'s area emulation reads the default website from the database (`The default website isn't defined`), so it needs a full `setup:install` (MySQL + OpenSearch). That infra is already covered end-to-end by `playwright.yml`; this gate stays deliberately DB-less and fast.

## Coverage

Minimal matrix — Mage-OS 3.1.0 / PHP 8.4. Triggers on PR + push to `main` (paths: `src/**`, `lib/**`, `dist/**`, `composer.json`, the workflow) and manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)