### PR TITLE
ci: lint PR titles against conventional-commit types

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,29 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate conventional-commit type
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            chore
+            docs
+            ci
+            test
+            build
+            style


### PR DESCRIPTION
## Why

release-please classifies changelog entries by the conventional-commit type on the squash commit subject. PRs merged without a valid type (e.g. #260 `Fix null array offset...`) are silently dropped from the release notes.

This adds a required-check candidate that validates every PR title starts with an allowed type.

## What

- `amannn/action-semantic-pull-request@v5` on `opened`/`edited`/`synchronize`
- Allowed types match `release-please-config.json` `changelog-sections`

## Follow-up (manual)

1. Mark **PR Title / Validate conventional-commit type** a required status check on `main`.
2. Set **Default to PR title for squash merge commits** (Settings → General → Pull Requests) — without it, single-commit PRs still leak the raw commit subject to `main`, which is the exact bug that dropped #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)