### PR TITLE
assignViaDots() leaks a PHP reference into component properties, breaking Rakit wildcard validation

### DIFF
--- a/src/Helper/Property.php
+++ b/src/Helper/Property.php
@@ -54,7 +54,42 @@ class Property
 
     public function assignViaDots(string $path, $value, array $subject)
     {
-        return $this->arrayManager->set($path, $subject, $value, '.');
+        return $this->detachReferences($this->arrayManager->set($path, $subject, $value, '.'));
+    }
+
+    /**
+     * Returns a copy in which no element is a PHP reference.
+     *
+     * ArrayManager::set() walks the path by reference and leaves one behind on the element it
+     * touched, so a component property such as `fields` ends up holding `&array` at the index
+     * that was written. References are invisible to json_encode() and var_export(), which makes
+     * the consequences look impossible:
+     *
+     *   - Rakit's wildcard resolution cannot read through a reference, so a rule like
+     *     `fields.*.sku` reports "required" against a value that is plainly set.
+     *   - Worse, Rakit writes back through it, nulling the value in the component's own property.
+     *     The next dehydration then drops the key entirely, so the field clears in the UI too.
+     *
+     * Reproducible without Magento or Magewire:
+     *
+     *   $data = ['fields' => [['sku' => 'ABC']]];
+     *   $ref  = &$data['fields'][0];
+     *   (new Validator())->make($data, ['fields.*.sku' => 'required'])->validate();  // fails
+     *
+     * Copying by value on the way out keeps the reference inside ArrayManager, where it belongs.
+     *
+     * @param array<mixed> $data
+     * @return array<mixed>
+     */
+    private function detachReferences(array $data): array
+    {
+        $copy = [];
+
+        foreach ($data as $key => $value) {
+            $copy[$key] = is_array($value) ? $this->detachReferences($value) : $value;
+        }
+
+        return $copy;
     }
 
     public function searchViaDots(string $path, array $value)


### PR DESCRIPTION
# Nested property assignment leaks a PHP reference, breaking wildcard validation

## Summary

`Helper\Property::assignViaDots()` returns the result of `ArrayManager::set()` unchanged.
`ArrayManager` walks the path by reference and leaves one behind on the element it writes, so a
component array property ends up holding `&array` at the index that was updated.

That reference breaks validation of the property in two ways:

1. Rakit cannot resolve a wildcard rule (`fields.*.sku`) through a reference, so `required` fails on
   a value that is plainly set.
2. Rakit **writes back through the reference**, setting the value to `null` in the component's own
   property. The next dehydration drops the now-null key, so the input clears itself in the browser.

The net effect is a form that rejects correct input with "… is required" and then wipes the field it
just rejected.

## Environment

| | |
|---|---|
| `magewirephp/magewire` | 1.13.3 |
| `magewirephp/validation` | 1.0.1 |
| Magento | 2.4.8-p4 |
| PHP | 8.3 |

## Minimal reproduction

No Magento and no Magewire required — this is the bundled validator on its own:

```php
use Rakit\Validation\Validator;

$rules = ['fields.*.sku' => 'required'];

// 1. plain array
$plain = ['fields' => [['sku' => 'ABC']]];
$a = (new Validator())->make($plain, $rules, []);
$a->validate();
var_dump($a->fails());   // false -- correct

// 2. identical array, but element 0 is a reference
$withRef = ['fields' => [['sku' => 'ABC']]];
$ref = &$withRef['fields'][0];

$b = (new Validator())->make($withRef, $rules, []);
$b->validate();
var_dump($b->fails());              // true
var_dump($b->errors()->toArray());  // ['fields.0.sku' => ['required' => 'The Fields 1 sku is required']]

var_dump($withRef);                 // ['fields' => [['sku' => null]]]  <-- input was mutated
```

The two arrays are indistinguishable to `json_encode()` and `var_export()`. Only `var_dump()` shows
the difference:

```
["fields"]=> array(1) { [0]=> &array(1) { ["sku"]=> string(3) "ABC" } }
                             ^
```

## Reproduction through a component

```php
class Example extends \Magewirephp\Magewire\Component\Form
{
    public array $fields = [];

    protected $rules = [
        'fields'       => 'array',
        'fields.*.sku' => 'required',
        'fields.*.qty' => 'required|numeric|min:1',
    ];

    public function mount(): void
    {
        $this->fields[] = ['id' => uniqid(), 'sku' => '', 'qty' => 1];
    }

    public function submit(): void
    {
        $this->validate();   // fails even though the values arrived correctly
    }
}
```

```html
<div>
    <?php foreach ($magewire->fields as $key => $row): ?>
        <input wire:model.defer="fields.<?= $key ?>.sku"/>
        <input wire:model.defer="fields.<?= $key ?>.qty"/>
    <?php endforeach ?>
    <button wire:click="submit">Submit</button>
</div>
```

Type a value into each input and press Submit.

**Expected:** validation passes.
**Actual:** `Sku is required` / `Quantity is required`, and both inputs clear.

Two observations that helped narrow this down, in case they help someone recognise the same bug:

- The client side is entirely healthy. `deferredActions` is populated and the request payload
  contains `{"type":"syncInput","payload":{"name":"fields.0.sku","value":"…"}}` for each field.
- An action that does **not** call `validate()` — for example one that appends a row — round-trips
  the same values perfectly and re-renders them. Only validating actions fail, which is what points
  at validation rather than at the binding.

Dumping `$this->fields` at the top of the action shows correct data, which makes the failure look
impossible until you reach for `var_dump()`.

## Root cause

`src/Helper/Property.php`:

```php
public function assignViaDots(string $path, $value, array $subject)
{
    return $this->arrayManager->set($path, $subject, $value, '.');
}
```

`Magento\Framework\Stdlib\ArrayManager::set()` builds the nested path using references and leaves one
on the element it wrote. The result is assigned straight onto the component property in
`src/Model/Action/SyncInput.php` (lines 72, 81 and 152 in 1.13.3), so the reference lives on the
component for the remainder of the request and is handed to the validator by
`Component\Form::validate()` through `getPublicProperties()`.

## Proposed fix

Copy by value on the way out, so the reference stays inside `ArrayManager` where it belongs:

```diff
--- a/src/Helper/Property.php
+++ b/src/Helper/Property.php
@@
     public function assignViaDots(string $path, $value, array $subject)
     {
-        return $this->arrayManager->set($path, $subject, $value, '.');
+        return $this->detachReferences($this->arrayManager->set($path, $subject, $value, '.'));
     }
+
+    /**
+     * Returns a copy in which no element is a PHP reference.
+     *
+     * ArrayManager::set() walks the path by reference and leaves one behind on the element it
+     * touched. References are invisible to json_encode() and var_export(), but Rakit cannot
+     * resolve a wildcard rule through one, and writes back through it into the component's own
+     * property.
+     *
+     * @param array<mixed> $data
+     * @return array<mixed>
+     */
+    private function detachReferences(array $data): array
+    {
+        $copy = [];
+
+        foreach ($data as $key => $value) {
+            $copy[$key] = is_array($value) ? $this->detachReferences($value) : $value;
+        }
+
+        return $copy;
+    }
```

Fixing it here covers every component with a nested array property, rather than requiring each
component to defend itself.

I have been running this against 1.13.3 and it resolves the issue with no side effects I have been
able to find. Happy to open a PR if the approach looks right to you.

### Alternative or additional places to fix

- **`magewirephp/validation`** could resolve wildcards through references instead of silently reading
  nothing. Worth considering separately: mutating the caller's input during validation is surprising
  in its own right, and it is what turns a confusing error message into data loss.
- **`Magento\Framework\Stdlib\ArrayManager`** is arguably behaving as designed; the fix belongs with
  the consumer that passes its output onward.

## Verification

Applied against 1.13.3 and exercised through a browser on a real store:

| Case | Before | After |
|---|---|---|
| One row, valid SKU and qty | "Sku is required", field cleared | added to cart |
| Two rows, both valid | same failure | both added to cart |
| Row left deliberately empty | correctly rejected | correctly rejected |