### PR TITLE
feat(container): add Magento app adapter

### DIFF
--- a/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
+++ b/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
@@ -69,6 +69,7 @@ adding Laravel's service container as a runtime dependency.
 - [x] Reduce `app()` to Laravel's two-branch shape: return the adapter for `null`, otherwise call `make($abstract, $arguments)`
 - [x] Preserve Magento ObjectManager compatibility methods that existing `app()` consumers may use (`get`, `create`, and `configure`)
 - [x] Add focused unit tests for routing, runtime overrides, identity, and failure behavior
+- [x] Add a separate GitHub Actions check that runs the focused unit tests on PHP 8.2
 - [x] Run a Magento-booting integration probe for preferences, virtual types, frontend aliases, and call-time constructor parameters
 - [ ] Exercise the feature against Illuminate 10 and 13 CI endpoints and the supported Magento/Mage-OS matrix
 - [ ] Document the supported Laravel-style surface and the intentionally unsupported Laravel Application APIs
@@ -281,6 +282,25 @@ would silently change every existing no-argument class lookup from shared to
 fresh and would leave interfaces, virtual types, aliases, and `app()` container
 methods unresolved.
 
+## ✅ Run focused unit tests as a separate pull-request check
+
+The PHPUnit-compatible tests under `tests/Unit` run in a dedicated GitHub
+Actions workflow on PHP 8.2. The workflow installs Magewire's dependencies from
+the public Mage-OS mirror without development packages and provisions a pinned
+PHPUnit 11 CLI without adding a repository-level test-runner dependency.
+
+**Reasoning**
+
+This makes the 14 tests visible as an independent merge check while preserving
+the package's PHP 8.2 floor. Selecting and wiring the repository's eventual Pest
+runner remains separate work.
+
+**Evidence**
+
+- `.github/workflows/unit-tests.yml`
+- `tests/Unit/ApplicationContainerTest.php`
+- `tests/Unit/ContainersTest.php`
+
 # Acceptance criteria
 
 - The same two helper branches used by Laravel 10–13 are visible in Magewire:
@@ -299,6 +319,7 @@ methods unresolved.
   and unchanged unless Portman independently proves otherwise.
 - Behavior is tested at Illuminate 10 and 13 endpoints and in both frontend and
   adminhtml Magento areas.
+- The focused unit suite runs as a separate GitHub Actions pull-request check.
 
 # Investigation
 
@@ -341,9 +362,10 @@ methods unresolved.
 - Whether parameterized construction of a named Magewire alias is used outside
   tests; it should still be designed correctly so the helper has one coherent
   contract.
-- Which PHP test runner lands first. PHPUnit-compatible contract tests now live
-  under `tests/Unit`, but adding the repository-level runner remains separate
-  work in `.agents/plans/pest-test-runner.md`.
+- The repository-level test runner remains separate work in
+  `.agents/plans/pest-test-runner.md`. Pull request #274 uses a pinned PHPUnit
+  CLI supplied by CI so its focused tests can run without deciding that wider
+  migration.
 
 # Tooling
 
@@ -375,3 +397,6 @@ methods unresolved.
   to `origin` for review.
 - 2026-08-13: Opened pull request
   [#274](https://github.com/magewirephp/magewire/pull/274).
+- 2026-08-17: Added a separate PHP 8.2 / PHPUnit 11 GitHub Actions check for
+  the 14 focused unit tests while leaving the repository-level Pest runner as
+  separate work.

--- a/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
+++ b/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
@@ -19,8 +19,9 @@ entire Laravel Foundation application.
 - Started: 2026-08-13
 - Initial type: Feature
 - Current type: Feature
-- Status: Implemented locally; cross-version and adminhtml matrix coverage remains
+- Status: Implemented and pushed; cross-version and adminhtml matrix coverage remains
 - Branch: `feat/app-helper-parity`
+- Remote branch: `origin/feat/app-helper-parity`
 - Laravel compatibility range: 10.x through 13.x
 - Ported Livewire baseline: 3.7.11
 
@@ -369,4 +370,5 @@ methods unresolved.
 - 2026-08-13: Removed public runtime `bind()` compatibility. Magento `di.xml`
   remains the only application binding source; the adapter retains the
   `singleton()` and `instance()` overlays required by ported Livewire code.
-- 2026-08-13: Created `feat/app-helper-parity` from `origin/main` for review.
+- 2026-08-13: Created `feat/app-helper-parity` from `origin/main` and pushed it
+  to `origin` for review.

--- a/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
+++ b/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
@@ -70,6 +70,7 @@ adding Laravel's service container as a runtime dependency.
 - [x] Preserve Magento ObjectManager compatibility methods that existing `app()` consumers may use (`get`, `create`, and `configure`)
 - [x] Add focused unit tests for routing, runtime overrides, identity, and failure behavior
 - [x] Add a separate GitHub Actions check that runs the focused unit tests on PHP 8.2
+- [x] Centralize unit, production-build, and Playwright results under one `Tests` workflow and README badge
 - [x] Run a Magento-booting integration probe for preferences, virtual types, frontend aliases, and call-time constructor parameters
 - [ ] Exercise the feature against Illuminate 10 and 13 CI endpoints and the supported Magento/Mage-OS matrix
 - [ ] Document the supported Laravel-style surface and the intentionally unsupported Laravel Application APIs
@@ -282,12 +283,12 @@ would silently change every existing no-argument class lookup from shared to
 fresh and would leave interfaces, virtual types, aliases, and `app()` container
 methods unresolved.
 
-## ✅ Run focused unit tests as a separate pull-request check
+## ✅ Run focused unit tests as a separate pull-request job
 
-The PHPUnit-compatible tests under `tests/Unit` run in a dedicated GitHub
-Actions workflow on PHP 8.2. The workflow installs Magewire's dependencies from
-the public Mage-OS mirror without development packages and provisions a pinned
-PHPUnit 11 CLI without adding a repository-level test-runner dependency.
+The PHPUnit-compatible tests under `tests/Unit` run in a dedicated reusable
+GitHub Actions workflow on PHP 8.2. The workflow installs Magewire's dependencies
+from the public Mage-OS mirror without development packages and provisions a
+pinned PHPUnit 11 CLI without adding a repository-level test-runner dependency.
 
 **Reasoning**
 
@@ -298,8 +299,29 @@ runner remains separate work.
 **Evidence**
 
 - `.github/workflows/unit-tests.yml`
+- `.github/workflows/tests.yml`
 - `tests/Unit/ApplicationContainerTest.php`
 - `tests/Unit/ContainersTest.php`
+
+## ✅ Publish one combined test-status badge
+
+The README displays one `Tests` badge backed by a caller workflow. That workflow
+runs the reusable unit, production-build, and Playwright suites concurrently.
+Any failing called suite makes the caller workflow, and therefore its badge,
+fail.
+
+**Reasoning**
+
+GitHub status badges represent one workflow. A caller workflow provides one
+authoritative result without copying the three suite implementations or adding
+an eventually consistent status-aggregation job.
+
+**Evidence**
+
+- `README.md`
+- `.github/workflows/tests.yml`
+- [GitHub reusable workflow documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations)
+- [GitHub workflow status badge documentation](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge)
 
 # Acceptance criteria
 
@@ -319,7 +341,10 @@ runner remains separate work.
   and unchanged unless Portman independently proves otherwise.
 - Behavior is tested at Illuminate 10 and 13 endpoints and in both frontend and
   adminhtml Magento areas.
-- The focused unit suite runs as a separate GitHub Actions pull-request check.
+- The focused unit suite runs as a separate job within the combined GitHub
+  Actions `Tests` pull-request check.
+- The README has one `Tests` badge representing unit, production-build, and
+  Playwright results.
 
 # Investigation
 
@@ -400,3 +425,6 @@ runner remains separate work.
 - 2026-08-17: Added a separate PHP 8.2 / PHPUnit 11 GitHub Actions check for
   the 14 focused unit tests while leaving the repository-level Pest runner as
   separate work.
+- 2026-08-18: Centralized unit, production-build, and Playwright suites under a
+  reusable `Tests` caller workflow and replaced their individual README badges
+  with one combined status badge.

--- a/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
+++ b/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
@@ -1,0 +1,372 @@
+# TL;DR
+
+Make Magewire's namespaced `app()` helper behave like Laravel's helper at the
+service-resolution boundary while keeping Magento's object manager, DI
+configuration, and existing Magewire container aliases as the source of truth.
+
+The current helper resolves concrete classes and the `livewire` / `redirect`
+aliases, but it drops every supplied constructor argument, cannot resolve
+interfaces or virtual types, returns an object without the Laravel-style
+container methods retained in ported code, and contains an unsupported object
+branch.
+
+The recommended implementation is a small Magento-backed application-container
+adapter. It should not import Laravel's container or attempt to emulate the
+entire Laravel Foundation application.
+
+# Context
+
+- Started: 2026-08-13
+- Initial type: Feature
+- Current type: Feature
+- Status: Implemented locally; cross-version and adminhtml matrix coverage remains
+- Branch: `feat/app-helper-parity`
+- Laravel compatibility range: 10.x through 13.x
+- Ported Livewire baseline: 3.7.11
+
+# Goal
+
+Allow Magewire consumers and retained Livewire code to use both Laravel helper
+forms:
+
+```php
+app();
+app(Service::class, ['constructorParameter' => $value]);
+```
+
+Resolution must use Magento preferences, virtual types, configured constructor
+arguments, shared instances, and Magewire's named container aliases without
+adding Laravel's service container as a runtime dependency.
+
+# Compatibility target
+
+| Usage | Target behavior |
+| --- | --- |
+| `app()` | Return Magewire's Magento-backed application-container adapter |
+| `app(Foo::class)` | Preserve current behavior by resolving through Magento `get()` |
+| `app(Foo::class, $parameters)` | Resolve a fresh object through Magento `create()` and forward the named constructor parameters |
+| `app(FooInterface::class)` | Resolve the Magento `di.xml` preference |
+| `app('configuredVirtualType')` | Resolve the Magento virtual type |
+| `app('livewire')` / `app('redirect')` | Preserve the existing area-scoped Magewire container aliases |
+| `app()->make(...)` / `makeWith(...)` / `get(...)` | Use the same resolution pipeline as direct `app(...)` calls |
+| `app()->has(...)` / `bound(...)` | Inspect runtime overrides, Magewire aliases, and Magento DI metadata without instantiating the service |
+| `app()->singleton(...)` / `instance(...)` | Provide request-scoped compatibility needed by retained Livewire internals |
+| Unsupported abstract | Throw one stable, contextual resolution exception rather than leaking an alias lookup failure |
+
+# Tasks
+
+- [x] Trace the current helper and its repository call sites
+- [x] Compare Laravel 10.x, 11.x, 12.x, and 13.x helper behavior
+- [x] Trace Laravel's parameterized resolution and shared-instance behavior
+- [x] Trace Magento `get()`, `create()`, preferences, virtual types, and constructor argument overrides
+- [x] Identify current Magewire aliases and retained container method calls
+- [x] Confirm the adapter return-type compatibility decision
+- [x] Define the exact public adapter contract and exception types
+- [x] Add a boot-safe lookup API to `Containers` for `has`, shared resolution, and parameterized alias construction
+- [x] Implement the Magento-backed application-container adapter in hand-written `lib/Magewire/` code
+- [x] Reduce `app()` to Laravel's two-branch shape: return the adapter for `null`, otherwise call `make($abstract, $arguments)`
+- [x] Preserve Magento ObjectManager compatibility methods that existing `app()` consumers may use (`get`, `create`, and `configure`)
+- [x] Add focused unit tests for routing, runtime overrides, identity, and failure behavior
+- [x] Run a Magento-booting integration probe for preferences, virtual types, frontend aliases, and call-time constructor parameters
+- [ ] Exercise the feature against Illuminate 10 and 13 CI endpoints and the supported Magento/Mage-OS matrix
+- [ ] Document the supported Laravel-style surface and the intentionally unsupported Laravel Application APIs
+- [x] Run Portman and verify that no generated `dist/` changes are required for this hand-written bridge
+- [x] Review backwards compatibility of the implementation before handoff
+- [ ] Add release notes before implementation is merged
+
+# Implementation plan
+
+## Phase 1 — Lock the contract with tests
+
+Add contract tests before changing the helper. Cover the complete compatibility
+table above, including object identity and failure behavior.
+
+Use small fixture types with:
+
+- an injectable object dependency;
+- a required scalar constructor parameter;
+- an interface plus Magento preference;
+- a virtual type;
+- shared and transient resolution expectations;
+- a runtime singleton and an already-created runtime instance.
+
+The Magento-booting test is required. A mocked ObjectManager can prove routing,
+but only a booted Magento container can prove that preferences, virtual types,
+compiled/developer factories, and area-scoped aliases behave the same way.
+
+## Phase 2 — Make `Containers` a safe named-binding registry
+
+Keep `Containers` as the owner of Magewire aliases registered in
+`etc/frontend/di.xml` and `etc/adminhtml/di.xml`. Add explicit APIs instead of
+using exceptions as lookup control flow:
+
+- `has(string $name): bool`;
+- shared lookup for the current `item()` behavior;
+- parameterized construction that retains the configured Magento type and calls
+  Magento creation with the supplied parameters.
+
+Lookup must be safe before the normal service-type boot has assembled the
+registry. Existing aliases must retain precedence over Magento fallback names,
+except that real class and interface identifiers keep their current direct
+resolution behavior.
+
+## Phase 3 — Add the Magento-backed adapter
+
+Create a hand-written `ApplicationContainer` (final name to be confirmed) under
+`lib/Magewire/`. Inject `ObjectManagerInterface`, Magento's ObjectManager
+`ConfigInterface`, and Magewire `Containers`.
+
+Recommended resolution precedence:
+
+1. request-scoped instance or singleton registered on the adapter;
+2. concrete class or interface resolved through Magento;
+3. Magewire named alias resolved through `Containers`;
+4. Magento fallback for virtual types and other configured identifiers;
+5. a stable Magewire binding-resolution exception.
+
+When parameters are empty, preserve the existing `ObjectManager::get()` path.
+When parameters are present, use `ObjectManager::create($abstract,
+$parameters)`. This is the Magento equivalent of Laravel's contextual build:
+call-time parameters create a fresh object and must not replace the shared
+instance.
+
+The first public surface should be intentionally bounded:
+
+- resolution: `make`, `makeWith`, `get`, `create`;
+- inspection: `has`, `bound`;
+- runtime compatibility required by retained Livewire code: `singleton`,
+  `instance`;
+- legacy Magento delegation: `configure`;
+- optional ArrayAccess only if it can be covered without widening the design.
+
+Implement `Psr\Container\ContainerInterface` if exceptions can honor its
+contract. Consider also implementing Magento's `ObjectManagerInterface` to
+reduce the return-type break from the current `app()` behavior. Do not claim
+`Illuminate\Contracts\Container\Container` compatibility unless every method
+in that interface is genuinely implemented across Illuminate 10–13.
+
+## Phase 4 — Simplify the helper
+
+Mirror Laravel's stable helper control flow:
+
+```php
+if ($abstract === null) {
+    return $container;
+}
+
+return $container->make($abstract, $arguments);
+```
+
+Keep the existing `$arguments` parameter name for backwards compatibility with
+PHP named arguments unless repository or usage evidence justifies a breaking
+rename to Laravel's `$parameters`. Update PHPDoc to use
+`string|class-string|null` and a conditional generic return type.
+
+Remove the object branch. Laravel documents a string/class-string/null abstract,
+and Magento ObjectManager `get()` accepts a type identifier, not an object.
+
+## Phase 5 — Regression and compatibility proof
+
+Explicitly prove the retained generated calls:
+
+- `app()->has('session.store')` returns `false` without a fatal method call;
+- `app()->singleton(EventBus::class)` registers a request-scoped shared binding;
+- `app()->instance(Mechanism::class, $mechanism)` returns that exact object on
+  later resolution;
+- `app('livewire')` and `app('redirect')` still return the existing configured
+  container instances;
+- `app(ResponseFactory::class)` reaches Magento preference resolution rather
+  than treating the interface name as a Magewire alias.
+
+Run formatting/static analysis, the focused PHP tests, the Magento integration
+test, and the existing Playwright suite. Run `portman build` as a verification
+step only; changes belong in `lib/`, not generated `dist/`.
+
+# Decisions
+
+## ✅ Magento remains the source of truth
+
+Static bindings, interface preferences, virtual types, constructor defaults,
+and object lifestyles remain configured by Magento DI. The adapter must not
+embed a second general-purpose dependency injection container.
+
+**Reasoning**
+
+Magewire runs inside Magento, and the current code already documents `di.xml`
+as the binding mechanism. Duplicating those bindings in a Laravel container
+would create divergent object graphs and lifecycle rules.
+
+**Evidence**
+
+- `src/etc/frontend/di.xml:454`
+- `src/etc/adminhtml/di.xml:409`
+- `lib/magewire-helpers.php:247`
+
+## ✅ Preserve ordinary no-parameter resolution
+
+Continue using Magento `get()` when no call-time parameters are supplied.
+
+**Reasoning**
+
+This retains the helper's current shared-instance behavior, as requested, and
+lets Magento preferences resolve before the adapter considers Magewire aliases.
+
+**Evidence**
+
+- `lib/magewire-helpers.php:249`
+- Magento `ObjectManager.php:65`
+
+## ✅ Parameters mean contextual fresh construction
+
+Any non-empty parameter array routes through Magento `create()` and is passed
+unchanged by constructor parameter name.
+
+**Reasoning**
+
+Laravel treats explicit parameters as a contextual build and bypasses a cached
+singleton for that resolution. Magento's `create()` is the only public API that
+both accepts call-time parameters and returns a fresh object.
+
+**Evidence**
+
+- Magento `ObjectManager.php:54`
+- Magento `Factory/Dynamic/Developer.php:22`
+- [Laravel 13 container resolution](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Container/Container.php)
+
+## ✅ Return an adapter from `app()`
+
+The implementation replaces the raw ObjectManager return value with a
+Magento-backed adapter and delegates ObjectManager-compatible methods through
+it.
+
+**Reasoning**
+
+This is the only approach that matches Laravel's `app()` shape and supports the
+`has`, `singleton`, and `instance` calls already retained in generated Magewire
+code. The compatibility audit must confirm whether consumers depend on the
+concrete `Magento\Framework\App\ObjectManager` return type.
+
+**Evidence**
+
+- `dist/EventBus.php:17`
+- `dist/Mechanisms/Mechanism.php:14`
+- `dist/Features/SupportRedirects/SupportRedirects.php:23`
+- `dist/Mechanisms/FrontendAssets/FrontendAssets.php:148`
+
+## ❌ Rejected: add `illuminate/container`
+
+Do not add Laravel's container as a second runtime container.
+
+**Reasoning**
+
+It would not know Magento preferences, virtual types, generated factories, or
+area-scoped DI without duplicating configuration and would create ambiguous
+ownership of shared instances.
+
+## ❌ Rejected: expose runtime `bind()`
+
+Application bindings remain in Magento `di.xml`. A runtime `bind()` would only
+affect later resolutions through Magewire's `app()` adapter and not services
+injected directly by Magento, creating two inconsistent dependency graphs.
+
+The adapter keeps only the runtime `singleton()` and `instance()` methods
+required by retained Livewire internals.
+
+## ❌ Rejected: change only `get()` to `create()`
+
+Using Magento `create()` for every class would consume `$arguments`, but it
+would silently change every existing no-argument class lookup from shared to
+fresh and would leave interfaces, virtual types, aliases, and `app()` container
+methods unresolved.
+
+# Acceptance criteria
+
+- The same two helper branches used by Laravel 10–13 are visible in Magewire:
+  return the container for `null`, otherwise delegate to `make` with parameters.
+- Existing no-parameter class calls and `livewire` / `redirect` aliases retain
+  their current identity behavior.
+- Call-time constructor parameters reach Magento by their named keys and produce
+  a fresh contextual object without replacing the normal shared object.
+- Magento class, interface preference, and virtual-type identifiers resolve.
+- The retained `has`, `singleton`, and `instance` call sites execute without
+  fatal errors and have covered request-scoped behavior.
+- Unknown identifiers fail consistently with the requested identifier in the
+  exception chain.
+- No Laravel container package or duplicate static binding registry is added.
+- The implementation is hand-written under `lib/`; `dist/` remains generated
+  and unchanged unless Portman independently proves otherwise.
+- Behavior is tested at Illuminate 10 and 13 endpoints and in both frontend and
+  adminhtml Magento areas.
+
+# Investigation
+
+## VERIFIED
+
+- Laravel 10, 11, 12, and 13 use the same `app()` control flow and forward the
+  second parameter directly to container `make()`.
+- Laravel treats explicit parameters as a contextual build and does not reuse or
+  replace the cached singleton for that build.
+- Magento `get()` returns a cached shared instance and accepts no arguments;
+  Magento `create()` accepts named arguments and creates a new object.
+- Magewire's helper never reads `$arguments`.
+- The current `class_exists()` gate excludes interfaces and Magento virtual
+  types before the ObjectManager can resolve them.
+- The current object branch passes an object into an API documented for a type
+  string.
+- Current area DI exposes only the `livewire` and `redirect` named Magewire
+  aliases.
+- Retained generated code calls `app()->has()`, `app()->singleton()`, and
+  `app()->instance()`, none of which exists on the raw ObjectManager returned by
+  the helper.
+
+## ASSUMED
+
+- External Magewire consumers may depend on `app()->get()`, `create()`, or
+  `configure()` because `app()` currently returns the concrete ObjectManager.
+  The adapter plan preserves these methods, but repository source cannot prove
+  external usage.
+- Keeping `$arguments` as the PHP parameter name is safer than renaming it to
+  Laravel's `$parameters`, because PHP named arguments make the current name
+  externally observable.
+
+## UNKNOWN
+
+- Whether any external consumer requires `app()` to be an `instanceof
+  Magento\Framework\App\ObjectManager` rather than only using its public
+  methods.
+- Whether ArrayAccess belongs in a future compatibility surface. It is
+  intentionally not part of this implementation.
+- Whether parameterized construction of a named Magewire alias is used outside
+  tests; it should still be designed correctly so the helper has one coherent
+  contract.
+- Which PHP test runner lands first. PHPUnit-compatible contract tests now live
+  under `tests/Unit`, but adding the repository-level runner remains separate
+  work in `.agents/plans/pest-test-runner.md`.
+
+# Tooling
+
+- `magewire-work`
+- Magewire, architecture, backwards-compatibility, best-practices, and Portman
+  skill guidance
+- Repository source and Git history
+- Laravel 10–13 framework source and Laravel 13 service-container documentation
+- Magento framework source and Adobe Commerce ObjectManager / DI documentation
+
+# Supporting documents
+
+- [Research and compatibility analysis](./investigation.md)
+
+# Change log
+
+- 2026-08-13: Work item created; Laravel 10–13 and Magento resolution behavior
+  verified; adapter-based implementation plan proposed.
+- 2026-08-13: Implemented `ApplicationContainer`, PSR-compatible not-found
+  failures, safe Magewire alias inspection, contextual constructor parameters,
+  runtime overrides, and ObjectManager method delegation. Added 14 focused
+  PHPUnit tests, verified the frontend Magento DI path, and confirmed Portman
+  leaves `dist/` unchanged. Illuminate/Magento matrix CI and adminhtml-area
+  coverage remain follow-up work.
+- 2026-08-13: Removed public runtime `bind()` compatibility. Magento `di.xml`
+  remains the only application binding source; the adapter retains the
+  `singleton()` and `instance()` overlays required by ported Livewire code.
+- 2026-08-13: Created `feat/app-helper-parity` from `origin/main` for review.

--- a/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
+++ b/.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md
@@ -19,9 +19,10 @@ entire Laravel Foundation application.
 - Started: 2026-08-13
 - Initial type: Feature
 - Current type: Feature
-- Status: Implemented and pushed; cross-version and adminhtml matrix coverage remains
+- Status: In review; cross-version and adminhtml matrix coverage remains
 - Branch: `feat/app-helper-parity`
 - Remote branch: `origin/feat/app-helper-parity`
+- Pull request: [#274](https://github.com/magewirephp/magewire/pull/274)
 - Laravel compatibility range: 10.x through 13.x
 - Ported Livewire baseline: 3.7.11
 
@@ -372,3 +373,5 @@ methods unresolved.
   `singleton()` and `instance()` overlays required by ported Livewire code.
 - 2026-08-13: Created `feat/app-helper-parity` from `origin/main` and pushed it
   to `origin` for review.
+- 2026-08-13: Opened pull request
+  [#274](https://github.com/magewirephp/magewire/pull/274).

--- a/.agents/plans/feat-2026-08-13-app-helper-parity/investigation.md
+++ b/.agents/plans/feat-2026-08-13-app-helper-parity/investigation.md
@@ -1,0 +1,258 @@
+# Research and compatibility analysis
+
+# Question
+
+What behavior is missing from Magewire's `app()` helper, and what is the
+narrowest Magento-native design that lets callers use it in the Laravel style
+without introducing Laravel's application container?
+
+# Upstream Laravel contract
+
+Laravel 10.x, 11.x, 12.x, and 13.x all implement the helper with the same two
+branches:
+
+1. `app()` returns the global container instance.
+2. `app($abstract, $parameters)` calls the container's
+   `make($abstract, $parameters)`.
+
+Official source:
+
+- [Laravel 10.x helper](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/helpers.php)
+- [Laravel 11.x helper](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/helpers.php)
+- [Laravel 12.x helper](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Foundation/helpers.php)
+- [Laravel 13.x helper](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Foundation/helpers.php)
+
+Laravel's supported abstract is documented as
+`string|class-string<TClass>|null`; an object is not part of the helper
+contract.
+
+Laravel's container `make()` delegates to `resolve()`. Explicit parameters make
+the resolution contextual. A contextual build does not return an existing
+singleton and does not replace the singleton after construction. Laravel also
+documents `makeWith()` for named constructor parameters, while `make()` accepts
+the same parameter array internally.
+
+Sources:
+
+- [Laravel 13.x service-container documentation](https://laravel.com/docs/13.x/container#the-make-method)
+- [Laravel 13.x Container source](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Container/Container.php)
+
+# Magento resolution contract
+
+Magento exposes two relevant ObjectManager operations:
+
+- `get($type)` resolves preferences and returns a cached shared instance;
+- `create($type, $arguments)` resolves preferences and creates a new instance
+  with call-time constructor arguments.
+
+Magento's runtime and compiled factories merge call-time values by constructor
+parameter name over configured DI arguments. Magento DI also owns interface
+preferences, virtual types, and object lifestyle configuration.
+
+Sources:
+
+- [Magento ObjectManager implementation](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/ObjectManager/ObjectManager.php)
+- [Adobe ObjectManager documentation](https://developer.adobe.com/commerce/php/development/components/object-manager/)
+- [Adobe DI configuration and object lifestyles](https://developer.adobe.com/commerce/php/development/build/dependency-injection-file/)
+- Local `Magento/Framework/ObjectManager/Factory/Dynamic/Developer.php:22`
+- Local `Magento/Framework/ObjectManager/ConfigInterface.php:35`
+
+Direct ObjectManager usage is normally discouraged. A framework compatibility
+helper is an explicit boundary where it is justified, but the implementation
+should isolate it in an injectable adapter rather than spreading more static
+ObjectManager calls.
+
+# Current Magewire behavior
+
+Current implementation: `lib/magewire-helpers.php:247`.
+
+| Input | Current path | Problem |
+| --- | --- | --- |
+| `app()` | Return raw Magento ObjectManager | Does not expose Laravel container methods |
+| Concrete class string | `ObjectManager::get()` | Works and returns a shared object |
+| Concrete class plus arguments | `ObjectManager::get()` | Arguments are silently discarded |
+| Interface string | Magewire `Containers::item()` | `class_exists()` is false, so Magento never sees the preference |
+| Virtual type string | Magewire `Containers::item()` | Virtual types are not PHP classes, so Magento never sees them |
+| `livewire` / `redirect` | Magewire `Containers::item()` | Works after the container service type is assembled |
+| Object abstract | `ObjectManager::get($object)` | Unsupported: Magento expects a type identifier string |
+| Unknown string | Magewire alias exception | Error describes an operation item rather than service resolution |
+
+The `$arguments` parameter is not referenced anywhere in the function.
+
+# Existing repository compatibility pressure
+
+The generated Livewire-derived code retained by Magewire already assumes
+Laravel container methods on the object returned by `app()`:
+
+- `dist/EventBus.php:19` calls `singleton()`;
+- `dist/Mechanisms/Mechanism.php:16` calls `instance()`;
+- `dist/Features/SupportRedirects/SupportRedirects.php:28` calls `has()`;
+- `dist/Mechanisms/FrontendAssets/FrontendAssets.php:148` calls `has()`.
+
+The raw Magento ObjectManager only exposes `get`, `create`, and `configure`, so
+these are latent fatal paths whenever executed.
+
+The repository also has an interface-resolution example inside the same helper:
+`response()` calls `app(ResponseFactory::class)` at
+`lib/magewire-helpers.php:327`. `ResponseFactory` is an interface, so the current
+`class_exists()` gate prevents Magento preference resolution.
+
+# Existing named bindings
+
+Magewire deliberately owns two Laravel-style string aliases in area-scoped DI:
+
+- `livewire` → `Magewirephp\Magewire\Containers\Livewire`;
+- `redirect` → `Magewirephp\Magewire\Containers\Redirect`.
+
+Evidence:
+
+- `src/etc/frontend/di.xml:465`
+- `src/etc/adminhtml/di.xml:420`
+- `lib/Magewire/ServiceType.php:68`
+
+These aliases should remain data-driven through DI and should not be hard-coded
+into the helper or adapter.
+
+# Recommended architecture
+
+## Helper
+
+Keep the public helper tiny and stable. It should obtain one Magento-managed
+`ApplicationContainer` adapter, return it for `null`, and otherwise delegate to
+its `make()` method with the supplied arguments.
+
+## Adapter
+
+The adapter owns compatibility semantics, not object construction. It delegates
+construction to Magento and stores only the request-scoped singleton and
+instance overrides needed by retained Livewire code. General application
+bindings remain exclusively in Magento `di.xml`.
+
+Responsibilities:
+
+- route class, interface, virtual type, and named alias resolution;
+- choose `get()` for current no-parameter behavior;
+- choose `create()` for contextual parameterized builds;
+- expose common Laravel-style resolution/inspection/runtime-binding methods;
+- delegate the old ObjectManager-compatible methods;
+- normalize exceptions;
+- remain a normal Magento shared service, giving its runtime registry a
+  per-request lifecycle.
+
+It should not:
+
+- parse or duplicate `di.xml` construction logic;
+- become a second static binding configuration system;
+- implement Laravel routing, paths, environment, locale, console detection, or
+  other `Illuminate\Foundation\Application` APIs;
+- claim the full `Illuminate\Contracts\Container\Container` interface with only
+  partial method coverage.
+
+## Named alias registry
+
+`Containers` remains responsible for aliases. It needs a non-throwing `has()`
+API and a parameterized make path that remembers the configured Magento type.
+This prevents the adapter from inspecting `ServiceType` internals or using
+exceptions for normal resolution routing.
+
+# Resolution and lifecycle details
+
+## Empty parameters
+
+Use Magento `get()`. This intentionally preserves existing Magewire behavior,
+even though Laravel auto-wired concrete classes are transient unless explicitly
+bound as singletons. Exact lifecycle identity between the two frameworks is not
+possible without violating the request to keep Magento behavior.
+
+## Non-empty parameters
+
+Use Magento `create()` with the array unchanged. Like Laravel's contextual
+build, the result is fresh and must not overwrite any shared instance or
+runtime singleton.
+
+## Runtime `instance` and `singleton`
+
+These are an adapter overlay, not mutations of Magento's protected shared
+instance store or global DI configuration.
+
+- `instance($abstract, $object)` stores and returns the exact object for later
+  no-parameter resolutions.
+- `singleton($abstract, $concrete = null)` records a request-scoped shared
+  binding and caches its first non-contextual resolution.
+- Explicit parameters bypass the cached runtime singleton for that one
+  contextual build.
+
+## `has` versus `bound`
+
+Laravel documents `bound()` as explicit binding inspection, while PSR `has()`
+asks whether the container can return an identifier. Define both deliberately:
+
+- `bound()` checks adapter runtime singletons and instances, Magewire named aliases, Magento
+  preferences, and virtual types;
+- `has()` additionally recognizes instantiable concrete classes, without
+  constructing them;
+- an unbound interface with no Magento preference returns `false`;
+- arbitrary Laravel-only keys such as `session.store` return `false` instead of
+  fatalling.
+
+# Backwards compatibility
+
+Changing `app()` from the concrete Magento ObjectManager to an adapter is the
+main risk.
+
+Mitigations:
+
+- expose and delegate `get`, `create`, and `configure`;
+- consider implementing Magento's `ObjectManagerInterface` as well as PSR
+  ContainerInterface if method signatures remain compatible across supported
+  Magento versions;
+- search public documentation and repository history for concrete type checks;
+- call out that concrete `instanceof Magento\Framework\App\ObjectManager`
+  cannot be preserved by composition;
+- keep `$arguments` as the PHP parameter name because named arguments make it
+  part of the effective public API.
+
+# Alternatives considered
+
+## Minimal conditional fix
+
+Change class resolution to `create()` only when `$arguments` is non-empty and
+add `interface_exists()`.
+
+This is a useful emergency patch but does not meet the stated goal. It leaves
+virtual types, `app()` container methods, named-binding inspection, and stable
+error behavior incomplete.
+
+## Return raw ObjectManager forever
+
+This preserves concrete return identity but cannot provide Laravel's container
+surface because PHP cannot add `make`, `has`, `singleton`, or `instance` to the
+existing Magento class.
+
+## Install or copy Laravel's container
+
+Rejected. A second general container would not understand Magento's DI graph
+without duplicated configuration and would introduce conflicting instance
+lifecycles.
+
+## Make `Containers` itself the entire adapter
+
+Rejected. `Containers` is a Magewire service-type registry with boot ordering
+responsibilities. Expanding it into the application container would mix named
+Magewire aliases, Magento object construction, and runtime overrides in one
+class.
+
+# Scope boundary
+
+"Works like Laravel" should mean Laravel-style helper and common container
+resolution behavior backed by Magento. It cannot honestly mean the complete
+Laravel Foundation Application API. Calls such as `app()->environment()`,
+`runningInConsole()`, `getLocale()`, path helpers, and router APIs require
+separate Magento-specific adapters if Magewire retains upstream code that uses
+them.
+
+Future Portman syncs should audit newly retained `app()->...` calls and either:
+
+- map the method into the bounded adapter surface;
+- augment the upstream feature to use Magento-native behavior; or
+- keep that upstream feature excluded.

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,27 +15,7 @@ name: 'Playwright (Mage-OS + Hyvä)'
 # Never commit the token — it is a license credential.
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'lib/**'
-      - 'dist/**'
-      - 'composer.json'
-      - 'tests/Playwright/**'
-      - '.github/workflows/playwright.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'lib/**'
-      - 'dist/**'
-      - 'composer.json'
-      - 'tests/Playwright/**'
-      - '.github/workflows/playwright.yml'
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -9,29 +9,11 @@ name: 'Production build'
 # uncompilable classes, or bad proxies/factories. It runs WITHOUT a database, env.php,
 # or a search engine (the Adobe Commerce Cloud / Mage-OS build phase) — module:enable
 # writes the module list to config.php, which is all di:compile needs. No secrets, no
-# services: fast and deterministic, so a green badge means a tag can ship without a
+# services: fast and deterministic, so a green job means a tag can ship without a
 # manual local compile test.
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'lib/**'
-      - 'dist/**'
-      - 'composer.json'
-      - '.github/workflows/production-build.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'lib/**'
-      - 'dist/**'
-      - 'composer.json'
-      - '.github/workflows/production-build.yml'
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,54 @@
+name: 'Tests'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'lib/**'
+      - 'dist/**'
+      - 'composer.json'
+      - 'tests/Unit/**'
+      - 'tests/Playwright/**'
+      - '.github/workflows/tests.yml'
+      - '.github/workflows/unit-tests.yml'
+      - '.github/workflows/production-build.yml'
+      - '.github/workflows/playwright.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'lib/**'
+      - 'dist/**'
+      - 'composer.json'
+      - 'tests/Unit/**'
+      - 'tests/Playwright/**'
+      - '.github/workflows/tests.yml'
+      - '.github/workflows/unit-tests.yml'
+      - '.github/workflows/production-build.yml'
+      - '.github/workflows/playwright.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  unit-tests:
+    name: 'Unit tests'
+    uses: ./.github/workflows/unit-tests.yml
+
+  production-build:
+    name: 'Production build'
+    uses: ./.github/workflows/production-build.yml
+
+  playwright:
+    name: 'Playwright'
+    uses: ./.github/workflows/playwright.yml
+    secrets: inherit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,25 +1,7 @@
 name: 'Unit tests'
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'lib/**'
-      - 'src/**'
-      - 'composer.json'
-      - 'tests/Unit/**'
-      - '.github/workflows/unit-tests.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'lib/**'
-      - 'src/**'
-      - 'composer.json'
-      - 'tests/Unit/**'
-      - '.github/workflows/unit-tests.yml'
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,60 @@
+name: 'Unit tests'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'lib/**'
+      - 'src/**'
+      - 'composer.json'
+      - 'tests/Unit/**'
+      - '.github/workflows/unit-tests.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'lib/**'
+      - 'src/**'
+      - 'composer.json'
+      - 'tests/Unit/**'
+      - '.github/workflows/unit-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  unit-tests:
+    name: 'PHPUnit / PHP 8.2'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: bcmath, ctype, curl, dom, gd, hash, iconv, intl, mbstring, openssl, simplexml, soap, sockets, xsl, zip
+          tools: composer:v2, phpunit:11.5.56
+          ini-values: memory_limit=-1
+        env:
+          COMPOSER_TOKEN: ${{ github.token }}
+
+      - name: Configure public Magento mirror
+        run: composer config --global repositories.magento composer https://mirror.mage-os.org/
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--no-dev --no-scripts --prefer-dist'
+
+      - name: Run unit tests
+        run: phpunit --bootstrap vendor/autoload.php --colors=always --do-not-cache-result tests/Unit

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 [![License](http://poser.pugx.org/magewirephp/magewire/license)](https://packagist.org/packages/magewirephp/magewire)
 
 - [![Mago](https://github.com/magewirephp/magewire/actions/workflows/mago.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/mago.yml)
-- [![Production build](https://github.com/magewirephp/magewire/actions/workflows/production-build.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/production-build.yml?query=branch%3Amain)
-- [![Playwright tests](https://github.com/magewirephp/magewire/actions/workflows/playwright.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/playwright.yml?query=branch%3Amain)
+- [![Tests](https://github.com/magewirephp/magewire/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/magewirephp/magewire/actions/workflows/tests.yml?query=branch%3Amain)
 
 MagewirePHP brings the power of reactive, server-driven UI development to Magento 2—without writing JavaScript.
 Inspired by Laravel Livewire, MagewirePHP lets you build dynamic, interactive frontend components using only PHP,

--- a/lib/Magewire/ApplicationContainer.php
+++ b/lib/Magewire/ApplicationContainer.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire;
+
+use Closure;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Magento\Framework\ObjectManager\ConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magewirephp\Magewire\Exceptions\ContainerEntryNotFoundException;
+use Psr\Container\ContainerInterface;
+use Throwable;
+
+/**
+ * Laravel-style service resolution backed by Magento's object manager.
+ *
+ * Static application bindings remain owned by Magento DI. Runtime singleton
+ * and instance overrides live for the lifetime of this shared object.
+ *
+ * @mago-expect lint:cyclomatic-complexity
+ * @mago-expect lint:too-many-methods
+ */
+class ApplicationContainer implements ContainerInterface, ObjectManagerInterface
+{
+    /** @var array<string, Closure|string> */
+    private array $singletons = [];
+
+    /** @var array<string, mixed> */
+    private array $instances = [];
+
+    /** @var list<string> */
+    private array $resolving = [];
+
+    public function __construct(
+        private readonly ObjectManagerInterface $objectManager,
+        private readonly ConfigInterface $config,
+        private readonly Containers $containers
+    ) {
+    }
+
+    /**
+     * Resolve a service using runtime overrides, Magewire aliases, and Magento DI.
+     *
+     * Explicit arguments always cause a fresh contextual build, matching
+     * Laravel's handling of parameters passed to Container::make().
+     */
+    public function make($abstract, array $parameters = []): mixed
+    {
+        $abstract = $this->normalizeAbstract($abstract);
+
+        if ($parameters === [] && array_key_exists($abstract, $this->instances)) {
+            return $this->instances[$abstract];
+        }
+
+        if (array_key_exists($abstract, $this->singletons)) {
+            return $this->resolveSingleton($abstract, $parameters);
+        }
+
+        return $this->resolveConfigured($abstract, $parameters);
+    }
+
+    public function makeWith($abstract, array $parameters = []): mixed
+    {
+        return $this->make($abstract, $parameters);
+    }
+
+    /**
+     * PSR container resolution entry point.
+     *
+     * @throws ContainerEntryNotFoundException
+     */
+    public function get($id): mixed
+    {
+        if (! is_string($id) || ! $this->has($id)) {
+            $id = is_string($id) ? $id : get_debug_type($id);
+
+            throw new ContainerEntryNotFoundException(sprintf('Target [%s] is not bound in Magewire or Magento DI.', $id));
+        }
+
+        return $this->make($id);
+    }
+
+    /**
+     * Preserve Magento ObjectManager::create() semantics for existing consumers.
+     */
+    public function create($type, array $arguments = []): mixed
+    {
+        return $this->objectManager->create($type, $arguments);
+    }
+
+    /**
+     * Preserve Magento ObjectManager::configure() semantics for existing consumers.
+     */
+    public function configure(array $configuration): void
+    {
+        $this->objectManager->configure($configuration);
+    }
+
+    public function has(string $id): bool
+    {
+        $id = ltrim($id, '\\');
+
+        if ($id === '') {
+            return false;
+        }
+
+        return $this->bound($id) || $this->isDirectMagentoType($id);
+    }
+
+    public function bound($abstract): bool
+    {
+        if (! is_string($abstract)) {
+            return false;
+        }
+
+        $abstract = ltrim($abstract, '\\');
+
+        if ($abstract === '') {
+            return false;
+        }
+
+        return array_key_exists($abstract, $this->instances) || array_key_exists($abstract, $this->singletons) || $this->containers->has($abstract) || $this->isConfiguredMagentoType($abstract);
+    }
+
+    public function singleton($abstract, $concrete = null): void
+    {
+        $abstract = $this->normalizeAbstract($abstract);
+        $concrete ??= $abstract;
+
+        if (! is_string($concrete) && ! $concrete instanceof Closure) {
+            throw new BindingResolutionException(sprintf('Singleton [%s] must resolve to a class name or closure; %s given.', $abstract, get_debug_type($concrete)));
+        }
+
+        unset($this->instances[$abstract]);
+
+        $this->singletons[$abstract] = $concrete;
+    }
+
+    public function instance($abstract, $instance): mixed
+    {
+        $abstract = $this->normalizeAbstract($abstract);
+
+        unset($this->singletons[$abstract]);
+
+        return $this->instances[$abstract] = $instance;
+    }
+
+    private function resolveSingleton(string $abstract, array $arguments): mixed
+    {
+        if (in_array($abstract, $this->resolving, true)) {
+            throw new BindingResolutionException(sprintf('Circular runtime singleton detected while resolving [%s].', implode(' -> ', [...$this->resolving, $abstract])));
+        }
+
+        $this->resolving[] = $abstract;
+
+        try {
+            $concrete = $this->singletons[$abstract];
+            $resolved = $this->resolveConcrete($abstract, $concrete, $arguments);
+
+            if ($arguments === []) {
+                $this->instances[$abstract] = $resolved;
+            }
+
+            return $resolved;
+        } finally {
+            array_pop($this->resolving);
+        }
+    }
+
+    private function resolveConcrete(string $abstract, Closure|string $concrete, array $arguments): mixed
+    {
+        if ($concrete instanceof Closure) {
+            return $concrete($this, $arguments);
+        }
+        if ($concrete === $abstract) {
+            return $this->resolveConfigured($concrete, $arguments);
+        }
+
+        return $this->make($concrete, $arguments);
+    }
+
+    private function resolveConfigured(string $abstract, array $arguments): mixed
+    {
+        if ($this->isDirectMagentoType($abstract)) {
+            return $this->resolveMagentoType($abstract, $arguments);
+        }
+
+        if ($this->containers->has($abstract)) {
+            if ($arguments === []) {
+                return $this->containers->item($abstract);
+            }
+
+            return $this->resolveMagentoType($this->containers->itemType($abstract), $arguments);
+        }
+
+        if ($this->isConfiguredMagentoType($abstract)) {
+            return $this->resolveMagentoType($abstract, $arguments);
+        }
+
+        throw new BindingResolutionException(sprintf('Target [%s] is not bound in Magewire or Magento DI.', $abstract));
+    }
+
+    private function resolveMagentoType(string $abstract, array $arguments): mixed
+    {
+        try {
+            return $arguments === [] ? $this->objectManager->get($abstract) : $this->objectManager->create($abstract, $arguments);
+        } catch (Throwable $exception) {
+            throw new BindingResolutionException(sprintf('Unable to resolve [%s] through Magento DI: %s', $abstract, $exception->getMessage()), 0, $exception);
+        }
+    }
+
+    private function isDirectMagentoType(string $abstract): bool
+    {
+        if (class_exists($abstract)) {
+            return true;
+        }
+
+        return interface_exists($abstract) && array_key_exists($abstract, $this->config->getPreferences());
+    }
+
+    private function isConfiguredMagentoType(string $abstract): bool
+    {
+        return array_key_exists($abstract, $this->config->getPreferences()) || array_key_exists($abstract, $this->config->getVirtualTypes());
+    }
+
+    private function normalizeAbstract(mixed $abstract): string
+    {
+        if (! is_string($abstract) || trim($abstract) === '') {
+            throw new BindingResolutionException(sprintf('Container abstracts must be non-empty strings; %s given.', get_debug_type($abstract)));
+        }
+
+        return ltrim($abstract, '\\');
+    }
+}

--- a/lib/Magewire/Containers.php
+++ b/lib/Magewire/Containers.php
@@ -11,10 +11,50 @@ declare(strict_types=1);
 
 namespace Magewirephp\Magewire;
 
+use Magento\Framework\Exception\NotFoundException;
 use Magewirephp\Magewire\Enums\ServiceTypeItemBootMode;
 
 class Containers extends ServiceType
 {
+    /**
+     * Determine whether an alias is configured without resolving it.
+     */
+    public function has(string $name): bool
+    {
+        return array_key_exists($this->normalizeItemName($name), $this->items);
+    }
+
+    /**
+     * Return the configured Magento type for an alias without resolving it.
+     *
+     * @throws NotFoundException
+     */
+    public function itemType(string $name): string
+    {
+        $name = $this->normalizeItemName($name);
+
+        if (! array_key_exists($name, $this->items)) {
+            throw new NotFoundException(__('Container item "%1" could not be found.', $name));
+        }
+
+        $item = $this->items[$name];
+
+        if (is_string($item)) {
+            return $item;
+        }
+
+        $type = $item['requested_type'] ?? $item['type'] ?? null;
+
+        if (is_string($type)) {
+            return $type;
+        }
+        if (is_object($type)) {
+            return $type::class;
+        }
+
+        throw new NotFoundException(__('Container item "%1" has no resolvable type.', $name));
+    }
+
     protected function callback(): callable
     {
         return static fn () => true;
@@ -23,5 +63,10 @@ class Containers extends ServiceType
     protected function getBootModeFallback(): ServiceTypeItemBootMode
     {
         return ServiceTypeItemBootMode::ALWAYS;
+    }
+
+    private function normalizeItemName(string $name): string
+    {
+        return preg_replace('/(?<!^)[A-Z]/', '_$0', $name) ?? $name;
     }
 }

--- a/lib/Magewire/Exceptions/ContainerEntryNotFoundException.php
+++ b/lib/Magewire/Exceptions/ContainerEntryNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Exceptions;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Psr\Container\NotFoundExceptionInterface;
+
+class ContainerEntryNotFoundException extends BindingResolutionException implements NotFoundExceptionInterface
+{
+}

--- a/lib/Magewire/ServiceType.php
+++ b/lib/Magewire/ServiceType.php
@@ -40,7 +40,7 @@ abstract class ServiceType
      * @param array<string, string|array> $items
      */
     public function __construct(
-        private array $items = []
+        protected array $items = []
     ) {
     }
 
@@ -68,6 +68,8 @@ abstract class ServiceType
     public function item(string $name): object
     {
         $name = preg_replace('/(?<!^)[A-Z]/', '_$0', $name);
+
+        $this->assemble();
 
         if (isset($this->items[$name])) {
             return $this->items[$name]['type'];
@@ -101,7 +103,10 @@ abstract class ServiceType
 
         foreach (array_filter($this->items, static fn ($value) => is_string($value) || is_array($value)) as $key => $item) {
             if (is_string($item)) {
-                $item = ['type' => $item];
+                $item = ['type' => $item, 'requested_type' => $item];
+            }
+            if (is_string($item['type'] ?? null)) {
+                $item['requested_type'] ??= $item['type'];
             }
             if (is_object($item['type'])) {
                 $assembled[$key] = $item;

--- a/lib/magewire-helpers.php
+++ b/lib/magewire-helpers.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\FileSystemException;
-use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Exception\RuntimeException;
 use Magewirephp\Magewire\Config as MagewireConfig;
 use Psr\Log\LoggerInterface;
@@ -236,29 +235,22 @@ function config(string $key, mixed $default = null): mixed
 }
 
 /**
- * Get the available container instance.
+ * Get the available Magento-backed application container or resolve a service.
  *
- * @param null  $abstract
- * @param array $arguments
- *
- * @return mixed
- * @throws NotFoundException
+ * @template T of object
+ * @param class-string<T>|string|null $abstract
+ * @param array<string, mixed> $arguments
+ * @return ($abstract is null ? ApplicationContainer : T|mixed)
  */
 function app($abstract = null, array $arguments = []): mixed
 {
-    if (is_string($abstract) && class_exists($abstract)) {
-        return ObjectManager::getInstance()->get($abstract);
-    }
+    $container = ObjectManager::getInstance()->get(ApplicationContainer::class);
+
     if (is_null($abstract)) {
-        return ObjectManager::getInstance();
-    }
-    if (is_object($abstract)) {
-        return ObjectManager::getInstance()->get($abstract);
+        return $container;
     }
 
-    $containers = ObjectManager::getInstance()->get(Containers::class);
-
-    return $containers->item($abstract);
+    return $container->make($abstract, $arguments);
 }
 
 /**

--- a/tests/Unit/ApplicationContainerTest.php
+++ b/tests/Unit/ApplicationContainerTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Magento\Framework\App\ObjectManager as GlobalObjectManager;
+use Magento\Framework\ObjectManager\ConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magewirephp\Magewire\ApplicationContainer;
+use Magewirephp\Magewire\Containers;
+use Magewirephp\Magewire\Exceptions\ContainerEntryNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\NotFoundExceptionInterface;
+use ReflectionProperty;
+use stdClass;
+
+use function Magewirephp\Magewire\app;
+
+require_once __DIR__ . '/Fixtures/ApplicationContainerFixture.php';
+
+/** @mago-expect lint:too-many-methods */
+class ApplicationContainerTest extends TestCase
+{
+    public function test_it_uses_magento_get_without_arguments(): void
+    {
+        $service = new ApplicationContainerFixture('shared');
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects(self::once())->method('get')->with(ApplicationContainerFixture::class)->willReturn($service);
+
+        $container = $this->createContainer($objectManager);
+
+        self::assertSame($service, $container->make(ApplicationContainerFixture::class));
+    }
+
+    public function test_it_forwards_arguments_to_a_fresh_magento_build(): void
+    {
+        $arguments = ['value' => 'contextual'];
+        $service = new ApplicationContainerFixture('contextual');
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects(self::once())->method('create')->with(ApplicationContainerFixture::class, $arguments)->willReturn($service);
+
+        $container = $this->createContainer($objectManager);
+
+        self::assertSame($service, $container->make(ApplicationContainerFixture::class, parameters: $arguments));
+    }
+
+    public function test_it_resolves_interfaces_through_magento_preferences(): void
+    {
+        $service = new ApplicationContainerFixture('preferred');
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects(self::once())->method('get')->with(ApplicationContainerFixtureContract::class)->willReturn($service);
+
+        $container = $this->createContainer($objectManager, preferences: [ApplicationContainerFixtureContract::class => ApplicationContainerFixture::class]);
+
+        self::assertSame($service, $container->make(ApplicationContainerFixtureContract::class));
+    }
+
+    public function test_it_resolves_magento_virtual_types(): void
+    {
+        $arguments = ['value' => 'virtual'];
+        $service = new ApplicationContainerFixture('virtual');
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects(self::once())->method('create')->with('fixture.virtual', $arguments)->willReturn($service);
+
+        $container = $this->createContainer($objectManager, virtualTypes: ['fixture.virtual' => ApplicationContainerFixture::class]);
+
+        self::assertSame($service, $container->make('fixture.virtual', $arguments));
+    }
+
+    public function test_it_preserves_shared_aliases_and_parameterizes_fresh_alias_builds(): void
+    {
+        $shared = new ApplicationContainerFixture('shared alias');
+        $fresh = new ApplicationContainerFixture('fresh alias');
+        $arguments = ['value' => 'fresh alias'];
+        $containers = $this->createMock(Containers::class);
+        $containers->method('has')->with('livewire')->willReturn(true);
+        $containers->expects(self::once())->method('item')->with('livewire')->willReturn($shared);
+        $containers->expects(self::once())->method('itemType')->with('livewire')->willReturn(ApplicationContainerFixture::class);
+
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects(self::once())->method('create')->with(ApplicationContainerFixture::class, $arguments)->willReturn($fresh);
+
+        $container = $this->createContainer($objectManager, $containers);
+
+        self::assertSame($shared, $container->make('livewire'));
+        self::assertSame($fresh, $container->make('livewire', $arguments));
+    }
+
+    public function test_runtime_singletons_are_shared_but_explicit_arguments_are_contextual(): void
+    {
+        $resolutions = 0;
+        $container = $this->createContainer();
+        $container->singleton('runtime.service', static function (
+            ApplicationContainer $container,
+            array $arguments
+        ) use (&$resolutions): ApplicationContainerFixture {
+            $resolutions++;
+
+            return new ApplicationContainerFixture($arguments['value'] ?? 'shared');
+        });
+
+        $shared = $container->make('runtime.service');
+        $contextual = $container->make('runtime.service', ['value' => 'contextual']);
+
+        self::assertSame($shared, $container->make('runtime.service'));
+        self::assertNotSame($shared, $contextual);
+        self::assertSame('contextual', $contextual->value);
+        self::assertSame(2, $resolutions);
+    }
+
+    public function test_default_singletons_resolve_through_magento_once(): void
+    {
+        $service = new ApplicationContainerFixture('shared');
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects(self::once())->method('get')->with(ApplicationContainerFixture::class)->willReturn($service);
+        $container = $this->createContainer($objectManager);
+        $container->singleton(ApplicationContainerFixture::class);
+
+        self::assertSame($service, $container->make(ApplicationContainerFixture::class));
+        self::assertSame($service, $container->make(ApplicationContainerFixture::class));
+    }
+
+    public function test_runtime_instances_are_returned_exactly(): void
+    {
+        $instance = new stdClass();
+        $container = $this->createContainer();
+
+        self::assertSame($instance, $container->instance('runtime.instance', $instance));
+        self::assertTrue($container->bound('runtime.instance'));
+        self::assertSame($instance, $container->make('runtime.instance'));
+    }
+
+    public function test_has_inspects_all_sources_without_resolving_services(): void
+    {
+        $containers = $this->createMock(Containers::class);
+        $containers->method('has')->willReturnCallback(static fn (string $id): bool => $id === 'livewire');
+        $container = $this->createContainer(
+            containers: $containers,
+            preferences: [ApplicationContainerFixtureContract::class => ApplicationContainerFixture::class],
+            virtualTypes: ['fixture.virtual' => ApplicationContainerFixture::class]
+        );
+        $container->singleton('runtime.singleton', static fn (): stdClass => new stdClass());
+
+        self::assertTrue($container->has(ApplicationContainerFixture::class));
+        self::assertFalse($container->bound(ApplicationContainerFixture::class));
+        self::assertTrue($container->has(ApplicationContainerFixtureContract::class));
+        self::assertTrue($container->bound(ApplicationContainerFixtureContract::class));
+        self::assertTrue($container->has('fixture.virtual'));
+        self::assertTrue($container->has('livewire'));
+        self::assertTrue($container->has('runtime.singleton'));
+        self::assertFalse($container->has('session.store'));
+    }
+
+    public function test_unknown_targets_have_stable_laravel_and_psr_exceptions(): void
+    {
+        $container = $this->createContainer();
+
+        try {
+            $container->get('missing.service');
+            self::fail('A missing PSR entry should throw.');
+        } catch (ContainerEntryNotFoundException $exception) {
+            self::assertInstanceOf(NotFoundExceptionInterface::class, $exception);
+            self::assertStringContainsString('missing.service', $exception->getMessage());
+        }
+
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('missing.service');
+
+        $container->make('missing.service');
+    }
+
+    public function test_it_delegates_legacy_object_manager_methods(): void
+    {
+        $arguments = ['value' => 'created'];
+        $configuration = ['preferences' => ['service' => ApplicationContainerFixture::class]];
+        $service = new ApplicationContainerFixture('created');
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects(self::once())->method('create')->with(ApplicationContainerFixture::class, $arguments)->willReturn($service);
+        $objectManager->expects(self::once())->method('configure')->with($configuration);
+        $container = $this->createContainer($objectManager);
+
+        self::assertSame($service, $container->create(ApplicationContainerFixture::class, $arguments));
+        $container->configure($configuration);
+    }
+
+    public function test_helper_returns_the_adapter_and_forwards_resolution_arguments(): void
+    {
+        $arguments = ['value' => 'helper'];
+        $service = new ApplicationContainerFixture('helper');
+        $container = $this->createMock(ApplicationContainer::class);
+        $container->expects(self::once())->method('make')->with(ApplicationContainerFixture::class, $arguments)->willReturn($service);
+
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects(self::exactly(2))->method('get')->with(ApplicationContainer::class)->willReturn($container);
+
+        $instanceProperty = new ReflectionProperty(GlobalObjectManager::class, '_instance');
+        $previousInstance = $instanceProperty->getValue();
+        GlobalObjectManager::setInstance($objectManager);
+
+        try {
+            self::assertSame($container, app());
+            self::assertSame($service, app(ApplicationContainerFixture::class, $arguments));
+        } finally {
+            $instanceProperty->setValue(null, $previousInstance);
+        }
+    }
+
+    /**
+     * @param array<string, string> $preferences
+     * @param array<string, string> $virtualTypes
+     */
+    private function createContainer(
+        ObjectManagerInterface|null $objectManager = null,
+        Containers|null $containers = null,
+        array $preferences = [],
+        array $virtualTypes = []
+    ): ApplicationContainer {
+        $config = $this->createMock(ConfigInterface::class);
+        $config->method('getPreferences')->willReturn($preferences);
+        $config->method('getVirtualTypes')->willReturn($virtualTypes);
+
+        return new ApplicationContainer($objectManager ?? $this->createMock(ObjectManagerInterface::class), $config, $containers ?? $this->containersWithoutAliases());
+    }
+
+    private function containersWithoutAliases(): Containers&MockObject
+    {
+        $containers = $this->createMock(Containers::class);
+        $containers->method('has')->willReturn(false);
+
+        return $containers;
+    }
+}

--- a/tests/Unit/ContainersTest.php
+++ b/tests/Unit/ContainersTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit;
+
+use Magewirephp\Magewire\Containers;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Fixtures/ApplicationContainerFixture.php';
+
+class ContainersTest extends TestCase
+{
+    public function test_it_inspects_aliases_without_resolving_them(): void
+    {
+        $containers = new Containers(['livewire' => ApplicationContainerFixture::class]);
+
+        self::assertTrue($containers->has('livewire'));
+        self::assertSame(ApplicationContainerFixture::class, $containers->itemType('livewire'));
+        self::assertFalse($containers->has('missing'));
+    }
+
+    public function test_it_retains_the_requested_type_after_assembly(): void
+    {
+        $service = new ApplicationContainerFixture('shared');
+        $containers = new Containers(['livewire' => ['type' => $service]]);
+
+        self::assertSame($service, $containers->item('livewire'));
+        self::assertSame(ApplicationContainerFixture::class, $containers->itemType('livewire'));
+    }
+}

--- a/tests/Unit/Fixtures/ApplicationContainerFixture.php
+++ b/tests/Unit/Fixtures/ApplicationContainerFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit;
+
+require_once __DIR__ . '/ApplicationContainerFixtureContract.php';
+
+class ApplicationContainerFixture implements ApplicationContainerFixtureContract
+{
+    public function __construct(
+        public readonly string $value
+    ) {
+    }
+}

--- a/tests/Unit/Fixtures/ApplicationContainerFixtureContract.php
+++ b/tests/Unit/Fixtures/ApplicationContainerFixtureContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit;
+
+interface ApplicationContainerFixtureContract
+{
+}


### PR DESCRIPTION
## Summary

- route `app()` through a Magento-backed application container
- preserve shared Magento `get()` behavior for ordinary resolution
- forward explicit constructor parameters through Magento `create()`
- support Magento preferences, virtual types, and Magewire aliases
- provide the retained Livewire `has()`, `singleton()`, and `instance()` compatibility surface
- keep application bindings exclusively in Magento `di.xml`; intentionally omit runtime `bind()`
- preserve legacy ObjectManager-compatible `get()`, `create()`, and `configure()` methods

## Verification

- 14 PHPUnit tests, 45 assertions
- focused Mago formatting and lint checks pass
- Magento frontend bootstrap verifies shared identity, contextual parameters, preferences, virtual types, and aliases
- Portman build succeeds and leaves `dist/` unchanged

## Follow-up coverage

Illuminate 13, adminhtml, and the broader supported Magento/Mage-OS matrix remain recorded as follow-up checks in the feature plan.

## Plan

`.agents/plans/feat-2026-08-13-app-helper-parity/PLAN.md`