### PR TITLE
feat(notifier): coalesce repeated messages

### DIFF
--- a/src/Controller/Playwright/Addons.php
+++ b/src/Controller/Playwright/Addons.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Controller\Playwright;
+
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magewirephp\Magewire\Controller\MagewireDeveloperAction;
+
+class Addons extends MagewireDeveloperAction implements HttpGetActionInterface
+{
+    protected string $pageTitle = 'Magewire / Playwright / Addons';
+}

--- a/src/view/base/templates/js/alpinejs/components/magewire-notifier.phtml
+++ b/src/view/base/templates/js/alpinejs/components/magewire-notifier.phtml
@@ -60,9 +60,25 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
                                 'x-bind:class'() {
                                     return [
                                         'message',
+                                        'relative',
                                         `${this.notification.type}`
                                     ];
                                 },
+                            }
+                        },
+
+                        occurrences: function() {
+                            return {
+                                'x-bind:class'() {
+                                    return {
+                                        'animate-bounce': this.notification.occurrences > 10
+                                    };
+                                },
+                                'x-bind:style'() {
+                                    return {
+                                        display: this.notification.occurrences > 1 ? 'flex' : 'none'
+                                    };
+                                }
                             }
                         },
 

--- a/src/view/base/templates/js/magewire/addons/notifier.phtml
+++ b/src/view/base/templates/js/magewire/addons/notifier.phtml
@@ -31,13 +31,15 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
             defaults: {
                 notification: {
                     state: '<?= $escaper->escapeJs(NotificationStateEnum::IDLE->state()) ?>',
-                    level: <?= $escaper->escapeJs(NotificationStateEnum::IDLE->level()) ?>,
+                    level: <?= $escaper->escapeJs((string) NotificationStateEnum::IDLE->level()) ?>,
                     type: '<?= $escaper->escapeJs(MessageType::INFO->type()) ?>',
                     duration: null,
                     recoverable: false,
+                    occurrences: 1,
 
                     hooks: {
                         onCreate: ({ notification }) => {},
+                        onUpdate: ({ notification, changes }) => {},
                         onActivate: ({ notification }) => {},
                         onCleanup: ({ notification }) => {},
                         onTerminate: ({ notification }) => {},
@@ -65,6 +67,29 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
                 });
             },
 
+            observe: function(subject) {
+                const notifier = this;
+                const notification = Alpine.reactive(subject);
+                let previous = notification.state;
+
+                Alpine.effect(() => {
+                    const state = notification.state;
+
+                    if (previous !== state) {
+                        <?php /* A negative level is allowed to be set when no matching level was found. */ ?>
+                        notification.level = levels.indexOf(state);
+
+                        if (typeof notification.hooks.onStateChange === 'function') {
+                            notifier.trigger('state-change', { state, previous, notification }, notification)
+                        }
+                    }
+
+                    previous = state;
+                });
+
+                return notification;
+            },
+
             create: async function(message, options = {}, hooks = {}) {
                 const { activate = true, ...notificationOptions } = options;
 
@@ -85,29 +110,28 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
                     notification.duration = window.MagewireUtilities.str.calculateReadingDurationByStrLength(notification.message);
                 }
 
+                const previous = this.notifications[this.notifications.length - 1] ?? null;
+
+                /*
+                 * Duplicate identity deliberately stops at message and type. Lifecycle fields,
+                 * hooks, and whichever markup renders the notification are not customer-visible
+                 * message identity. Only an active, immediately preceding notification is reused;
+                 * a message that has already disappeared should be allowed to surface again.
+                 */
+                if (activate
+                    && previous?.active === true
+                    && previous.message === notification.message
+                    && previous.type === notification.type
+                ) {
+                    return this.update(previous.id, {
+                        occurrences: (previous.occurrences ?? 1) + 1
+                    }, hooks);
+                }
+
                 notification.id = Math.floor(Math.random() * 2147483647);
                 notification.state = this.defaults.notification.state;
                 notification.active = false;
-
-                const notifier = this;
-
-                notification = new Proxy(notification, {
-                    set(target, property, value) {
-                        const previous = target[property];
-                        target[property] = value;
-
-                        if (property === 'state' && previous !== value) {
-                            <?php /* A negative level is allowed to be set when no matching level was found. */ ?>
-                            notification.level = levels.indexOf(value);
-
-                            if (typeof target.hooks.onStateChange === 'function') {
-                                notifier.trigger('state-change', { state: value, previous, notification }, notification)
-                            }
-                        }
-
-                        return true;
-                    }
-                });
+                notification = this.observe(notification);
 
                 this.notifications.push(notification);
 
@@ -122,6 +146,25 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
 
             get: function(id) {
                 return this.notifications.find(notification => notification.id === id) ?? null;
+            },
+
+            update: async function(id, changes = {}, hooks = {}) {
+                const notification = await this.hold(id);
+
+                if (! notification) {
+                    return null;
+                }
+
+                Object.assign(notification, changes);
+                notification.hooks = { ...notification.hooks, ...hooks };
+
+                await this.trigger('update', { notification, changes }, notification);
+
+                if (notification.active) {
+                    await this.cleanup(id);
+                }
+
+                return notification;
             },
 
             activate: async function(id) {
@@ -183,7 +226,7 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
             hold: async function(id) {
                 const notification = this.get(id);
 
-                if (notification.timeout) {
+                if (notification?.timeout) {
                     clearTimeout(notification.timeout);
                 }
 

--- a/src/view/base/templates/js/magewire/addons/notifier.phtml
+++ b/src/view/base/templates/js/magewire/addons/notifier.phtml
@@ -112,12 +112,12 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
 
                 const previous = this.notifications[this.notifications.length - 1] ?? null;
 
-                /*
+                <?php /*
                  * Duplicate identity deliberately stops at message and type. Lifecycle fields,
                  * hooks, and whichever markup renders the notification are not customer-visible
                  * message identity. Only an active, immediately preceding notification is reused;
                  * a message that has already disappeared should be allowed to surface again.
-                 */
+                 */ ?>
                 if (activate
                     && previous?.active === true
                     && previous.message === notification.message

--- a/src/view/base/templates/magewire/ui-components/notifier.phtml
+++ b/src/view/base/templates/magewire/ui-components/notifier.phtml
@@ -32,6 +32,18 @@ $layoutUtil = $magewireViewModel->utils()->layout();
             x-transition:leave.duration.100ms
             x-bind="bindings.notification.item.root"
         >
+            <span
+                class="magewire-notifier-occurrences absolute -right-2 -top-2 flex h-5 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold leading-none shadow"
+                x-bind="bindings.notification.item.occurrences"
+            >
+                <span class="sr-only">
+                    <?= $escaper->escapeHtml(__('Notification occurrences:')) ?>
+                </span>
+                <span aria-hidden="true" x-text="notification.occurrences">
+                    <!-- Notification occurrence count placeholder. -->
+                </span>
+            </span>
+
             <?php if ($layoutUtil->canContainerizeBlock($notificationsBeforeBlock)): ?>
                 <div class="magewire-notifier-before">
                     <?= $layoutUtil->renderBlockAsContainer($notificationsBeforeBlock) ?>

--- a/src/view/frontend/layout/magewire_playwright_addons.xml
+++ b/src/view/frontend/layout/magewire_playwright_addons.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd"
+      layout="1column"
+>
+    <body>
+        <referenceContainer name="content">
+            <container name="magewire.playwright.addons"
+                       htmlClass="grid grid-cols-1 gap-8"
+                       htmlId="magewire-playwright-addons"
+                       htmlTag="div"
+            >
+                <block name="magewire.playwright.addons.notifier"
+                       template="Magewirephp_Magewire::tests/magewire/playwright/addons/notifier.phtml"
+                />
+            </container>
+        </referenceContainer>
+    </body>
+</page>

--- a/src/view/frontend/templates/tests/magewire/playwright/addons/notifier.phtml
+++ b/src/view/frontend/templates/tests/magewire/playwright/addons/notifier.phtml
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Template $block */
+/** @var Escaper $escaper */
+?>
+<section data-testid="addons-notifier" x-data="magewirePlaywrightNotifier">
+    <h2><?= $escaper->escapeHtml(__('Notifier addon')) ?></h2>
+
+    <label>
+        <span><?= $escaper->escapeHtml(__('Message')) ?></span>
+        <input type="text" data-testid="addons-notifier-message" x-model="message">
+    </label>
+
+    <label>
+        <span><?= $escaper->escapeHtml(__('Type')) ?></span>
+        <select data-testid="addons-notifier-type" x-model="type">
+            <option value="success"><?= $escaper->escapeHtml(__('Success')) ?></option>
+            <option value="info"><?= $escaper->escapeHtml(__('Info')) ?></option>
+            <option value="warning"><?= $escaper->escapeHtml(__('Warning')) ?></option>
+            <option value="error"><?= $escaper->escapeHtml(__('Error')) ?></option>
+        </select>
+    </label>
+
+    <button type="button" data-testid="addons-notifier-create" x-on:click="notify">
+        <?= $escaper->escapeHtml(__('Create notification')) ?>
+    </button>
+
+    <output data-testid="addons-notifier-submissions" x-text="submissions">0</output>
+    <output data-testid="addons-notifier-id" x-text="notification.id">0</output>
+    <output data-testid="addons-notifier-occurrences" x-text="notification.occurrences">0</output>
+    <output data-testid="addons-notifier-total" x-text="notification.total">0</output>
+</section>
+
+<script>
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('magewirePlaywrightNotifier', () => ({
+            message: '',
+            type: 'info',
+            submissions: 0,
+            notification: {
+                id: 0,
+                occurrences: 0,
+                total: 0
+            },
+
+            async notify() {
+                const notifier = window.MagewireAddons.notifier;
+                const notification = await notifier.create(this.message, {
+                    type: this.type,
+                    duration: false
+                });
+
+                this.notification = {
+                    id: notification.id,
+                    occurrences: notification.occurrences,
+                    total: notifier.notifications.length
+                };
+                this.submissions += 1;
+            }
+        }));
+    }, { once: true });
+</script>

--- a/tests/Playwright/tests/notifier.spec.js
+++ b/tests/Playwright/tests/notifier.spec.js
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test';
+
+const PATH = '/magewire/playwright/addons';
+const notifierFixture = page => page.getByTestId('addons-notifier');
+const notifications = page => page.locator('.magewire-notifier-message');
+const occurrenceBadge = page => page.locator('.magewire-notifier-occurrences');
+const occurrenceBadgeOfType = (page, type) => page.locator(`.message.${type} .magewire-notifier-occurrences`);
+const occurrenceBadgeValue = page => occurrenceBadge(page).locator('[aria-hidden="true"]');
+const visibleOccurrenceBadges = page => page.locator('.magewire-notifier-occurrences:visible');
+
+async function createNotification(page, message, type = 'warning') {
+    const fixture = notifierFixture(page);
+    const submissions = fixture.getByTestId('addons-notifier-submissions');
+    const submission = Number(await submissions.textContent()) + 1;
+
+    await fixture.getByTestId('addons-notifier-message').fill(message);
+    await fixture.getByTestId('addons-notifier-type').selectOption(type);
+    await fixture.getByTestId('addons-notifier-create').click();
+    await expect(submissions).toHaveText(String(submission));
+
+    return {
+        id: Number(await fixture.getByTestId('addons-notifier-id').textContent()),
+        occurrences: Number(await fixture.getByTestId('addons-notifier-occurrences').textContent()),
+        total: Number(await fixture.getByTestId('addons-notifier-total').textContent()),
+    };
+}
+
+test.describe('Magewire Playwright — Notifier', () => {
+    test.beforeEach(async ({ page }) => {
+        const version = Math.floor(Math.random() * 1_000_000);
+        await page.goto(`${PATH}?v=${version}`);
+        await page.waitForFunction(() => window.MagewireAddons?.notifier);
+        await expect(notifierFixture(page).getByRole('heading')).toHaveText('Notifier addon');
+    });
+
+    test('updates the previous active notification when its message and type are equal', async ({ page }) => {
+        const first = await createNotification(page, 'Too many requests! Please wait.');
+
+        await expect(notifications(page)).toHaveCount(1);
+        await expect(visibleOccurrenceBadges(page)).toHaveCount(0);
+
+        const second = await createNotification(page, 'Too many requests! Please wait.');
+
+        expect(second.id).toBe(first.id);
+        expect(second.total).toBe(1);
+        expect(second.occurrences).toBe(2);
+
+        await expect(occurrenceBadgeValue(page)).toHaveText('2');
+        await expect(occurrenceBadge(page)).toBeVisible();
+    });
+
+    test('keeps a two-digit occurrence count readable in a content-sized badge', async ({ page }) => {
+        let notification;
+
+        for (let occurrence = 1; occurrence <= 10; occurrence += 1) {
+            notification = await createNotification(page, 'Still too many requests.');
+        }
+
+        expect(notification.total).toBe(1);
+        expect(notification.occurrences).toBe(10);
+
+        await expect(occurrenceBadgeValue(page)).toHaveText('10');
+        await expect(occurrenceBadge(page)).toBeVisible();
+
+        const dimensions = await occurrenceBadge(page).evaluate(element => ({
+            height: element.offsetHeight,
+            width: element.offsetWidth,
+        }));
+
+        expect(dimensions.width).toBeGreaterThan(dimensions.height);
+    });
+
+    test('starts bouncing only after the occurrence count passes ten', async ({ page }) => {
+        let notification;
+
+        for (let occurrence = 1; occurrence <= 10; occurrence += 1) {
+            notification = await createNotification(page, 'Keep warning me.');
+        }
+
+        expect(notification.occurrences).toBe(10);
+        await expect(occurrenceBadge(page)).not.toHaveClass(/\banimate-bounce\b/);
+
+        notification = await createNotification(page, 'Keep warning me.');
+
+        expect(notification.occurrences).toBe(11);
+        await expect(occurrenceBadge(page)).toHaveClass(/\banimate-bounce\b/);
+    });
+
+    test('exposes the notification type as the badge styling hook', async ({ page }) => {
+        const types = ['success', 'info', 'warning', 'error'];
+
+        for (const type of types) {
+            await createNotification(page, `${type} notification.`, type);
+            await createNotification(page, `${type} notification.`, type);
+        }
+
+        for (const type of types) {
+            await expect(occurrenceBadgeOfType(page, type)).toBeVisible();
+        }
+    });
+
+    test('keeps equal text with a different type as a separate notification', async ({ page }) => {
+        await createNotification(page, 'Connection changed.', 'warning');
+        const second = await createNotification(page, 'Connection changed.', 'error');
+
+        expect(second.total).toBe(2);
+        expect(second.occurrences).toBe(1);
+
+        await expect(notifications(page)).toHaveCount(2);
+        await expect(visibleOccurrenceBadges(page)).toHaveCount(0);
+    });
+
+    test('keeps different text with the same type as a separate notification', async ({ page }) => {
+        await createNotification(page, 'First warning.');
+        const second = await createNotification(page, 'Second warning.');
+
+        expect(second.total).toBe(2);
+        expect(second.occurrences).toBe(1);
+
+        await expect(notifications(page)).toHaveCount(2);
+        await expect(visibleOccurrenceBadges(page)).toHaveCount(0);
+    });
+
+    test('preserves notification state-change hooks', async ({ page }) => {
+        const states = await page.evaluate(async () => {
+            const states = [];
+
+            await window.MagewireAddons.notifier.create(
+                'Track my lifecycle.',
+                { duration: false },
+                { onStateChange: ({ state }) => states.push(state) }
+            );
+
+            return states;
+        });
+
+        expect(states).toEqual(['running', 'succeeded']);
+    });
+});


### PR DESCRIPTION
## Summary

- reuse the previous active notification when message and type match
- expose occurrence counts through the notifier API
- render a content-sized badge that bounces above ten occurrences
- add a dedicated addon fixture route and Playwright coverage

## Compatibility

The matching Hyvä theme presentation is tracked in https://github.com/magewirephp/magewire-hyva-theme/pull/1 and requires Magewire 3.6 or newer.

## Verification

- Magento DI compilation
- 7 notifier Playwright tests
- Mago lint
- XML validation
- diff checks