### PR TITLE
feat(rate-limiting): add temporary lockouts

### DIFF
--- a/lib/Magewire/Exceptions/RequestFilterException.php
+++ b/lib/Magewire/Exceptions/RequestFilterException.php
@@ -76,4 +76,14 @@ abstract class RequestFilterException extends RuntimeException
     {
         return MessageType::WARNING;
     }
+
+    /**
+     * Additional response headers carried by this rejection.
+     *
+     * @return array<string, string>
+     */
+    public function headers(): array
+    {
+        return [];
+    }
 }

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/Exceptions/TooManyRequestsException.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/Exceptions/TooManyRequestsException.php
@@ -25,4 +25,9 @@ class TooManyRequestsException extends RequestFilterException
     {
         return 429;
     }
+
+    public static function forLockout(int $remainingSeconds): static
+    {
+        return new static((string) __('You have been temporarily locked out due to too many requests. Try again in %1 seconds.', max(1, $remainingSeconds)));
+    }
 }

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/Exceptions/TooManyRequestsException.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/Exceptions/TooManyRequestsException.php
@@ -16,6 +16,8 @@ use Throwable;
 
 class TooManyRequestsException extends RequestFilterException
 {
+    private int|null $retryAfterSeconds = null;
+
     public function __construct(string $message = '', int $code = 0, Throwable|null $previous = null)
     {
         parent::__construct($message === '' ? (string) __('Too many requests! Please wait.') : $message, $code, $previous);
@@ -28,6 +30,21 @@ class TooManyRequestsException extends RequestFilterException
 
     public static function forLockout(int $remainingSeconds): static
     {
-        return new static((string) __('You have been temporarily locked out due to too many requests. Try again in %1 seconds.', max(1, $remainingSeconds)));
+        $remainingSeconds = max(1, $remainingSeconds);
+        $exception = new static((string) __('You have been temporarily locked out due to too many requests. Try again in %1 seconds.', $remainingSeconds));
+        $exception->retryAfterSeconds = $remainingSeconds;
+
+        return $exception;
+    }
+
+    public function headers(): array
+    {
+        $headers = parent::headers();
+
+        if ($this->retryAfterSeconds !== null) {
+            $headers['Retry-After'] = (string) $this->retryAfterSeconds;
+        }
+
+        return $headers;
     }
 }

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/Filter/RateLimitFilter.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/Filter/RateLimitFilter.php
@@ -14,6 +14,7 @@ namespace Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Filter;
 use Magento\Framework\App\State as ApplicationState;
 use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Exceptions\TooManyRequestsException;
 use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimiterConfig;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimitLockout;
 use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\UpdateRequestRateLimiter;
 use Magewirephp\Magewire\Mechanisms\HandleRequests\Filter\RequestFilterInterface;
 use Magewirephp\Magewire\Mechanisms\HandleRequests\RequestContext;
@@ -37,6 +38,7 @@ class RateLimitFilter implements RequestFilterInterface
 
     public function __construct(
         private readonly UpdateRequestRateLimiter $rateLimiter,
+        private readonly RateLimitLockout $lockout,
         private readonly RateLimiterConfig $rateLimiterConfig,
         private readonly ApplicationState $applicationState
     ) {
@@ -45,6 +47,20 @@ class RateLimitFilter implements RequestFilterInterface
     public function check(RequestContext $context): void
     {
         if (! $this->canRateLimit()) {
+            return;
+        }
+
+        $remainingLockoutSeconds = $this->lockout->remainingSeconds();
+
+        if ($remainingLockoutSeconds > 0) {
+            throw TooManyRequestsException::forLockout($remainingLockoutSeconds);
+        }
+
+        /*
+         * Component-scoped limiting still needs reconstruction, but an already active lockout can
+         * be rejected here before that work starts.
+         */
+        if (! $this->rateLimiterConfig->canRateLimitRequests()) {
             return;
         }
 
@@ -57,6 +73,12 @@ class RateLimitFilter implements RequestFilterInterface
         $context->attributes()->set(self::ATTRIBUTE, $passed);
 
         if (! $passed) {
+            $remainingLockoutSeconds = $this->lockout->registerRejection($this->rateLimiterConfig->getRequestsDecaySeconds());
+
+            if ($remainingLockoutSeconds > 0) {
+                throw TooManyRequestsException::forLockout($remainingLockoutSeconds);
+            }
+
             throw new TooManyRequestsException();
         }
     }
@@ -72,7 +94,7 @@ class RateLimitFilter implements RequestFilterInterface
             return false;
         }
 
-        return $this->rateLimiterConfig->canRateLimitRequests();
+        return $this->rateLimiterConfig->canRateLimit();
     }
 
     /**

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/RateLimitLockout.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/RateLimitLockout.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Features\SupportMagewireRateLimiting;
+
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magewirephp\Magewire\Mechanisms\HandleRequests\RequestFingerprint;
+
+/**
+ * Escalates repeated rate-limit rejections into a temporary, origin-wide lockout.
+ *
+ * Warnings use the same decay window as the limiter that raised them. A visitor therefore has to
+ * trigger the configured number of rejections inside one active window; old warnings do not build
+ * up into a lock much later.
+ */
+class RateLimitLockout
+{
+    private const KEY_PREFIX = 'magewire@rate-limit-lockout@';
+
+    public function __construct(
+        private readonly RateLimiterStorageInterface $storage,
+        private readonly DateTime $dateTime,
+        private readonly RateLimiterConfig $config,
+        private readonly RequestFingerprint $requestFingerprint
+    ) {
+    }
+
+    /**
+     * Return the number of whole seconds left on the current origin's lockout.
+     */
+    public function remainingSeconds(): int
+    {
+        if (! $this->config->canLockout()) {
+            return 0;
+        }
+
+        $key = $this->lockKey();
+        $lockedUntil = (int) ( $this->storage->get($key)[0] ?? 0 );
+        $remaining = $lockedUntil - $this->dateTime->gmtTimestamp();
+
+        if ($remaining <= 0 && $lockedUntil !== 0) {
+            $this->storage->unset($key);
+        }
+
+        return max(0, $remaining);
+    }
+
+    /**
+     * Record a customer-visible rate-limit rejection.
+     *
+     * Returns the lockout duration when this rejection starts a lock, the remaining duration when
+     * a concurrent request finds an existing lock, or zero while the warning threshold has not
+     * been reached.
+     */
+    public function registerRejection(int $decaySeconds): int
+    {
+        if (! $this->config->canLockout()) {
+            return 0;
+        }
+
+        $remaining = $this->remainingSeconds();
+
+        if ($remaining > 0) {
+            return $remaining;
+        }
+
+        $decaySeconds = max(1, $decaySeconds);
+        $currentTime = $this->dateTime->gmtTimestamp();
+        $warningKey = $this->warningKey();
+        $warnings = array_values(array_filter(
+            $this->storage->get($warningKey),
+            static fn (mixed $timestamp): bool => is_int($timestamp) && $timestamp <= $currentTime && ( $currentTime - $timestamp ) < $decaySeconds
+        ));
+
+        $warnings[] = $currentTime;
+
+        if (count($warnings) < $this->config->getLockoutWarningThreshold()) {
+            $this->storage->set($warningKey, $warnings, $decaySeconds);
+
+            return 0;
+        }
+
+        $duration = $this->config->getLockoutSeconds();
+
+        $this->storage->unset($warningKey);
+        $this->storage->set($this->lockKey(), [$currentTime + $duration], $duration);
+
+        return $duration;
+    }
+
+    private function warningKey(): string
+    {
+        return $this->key('warnings');
+    }
+
+    private function lockKey(): string
+    {
+        return $this->key('lock');
+    }
+
+    private function key(string $suffix): string
+    {
+        return self::KEY_PREFIX . $this->requestFingerprint->resolve() . '@' . $suffix;
+    }
+}

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/RateLimiterConfig.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/RateLimiterConfig.php
@@ -15,6 +15,7 @@ use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Config\Source\Rate
 use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Config\Source\RequestsScope;
 use Magewirephp\Magewire\Model\Magento\System\ConfigMagewireGroup;
 
+/** @mago-expect lint:too-many-methods */
 class RateLimiterConfig extends ConfigMagewireGroup
 {
     public function throttleInDeveloperMode(): bool
@@ -30,6 +31,16 @@ class RateLimiterConfig extends ConfigMagewireGroup
     public function canRateLimitComponents(): bool
     {
         return $this->getRateLimitingVariant() === RateLimitingVariant::COMPONENTS_ONLY;
+    }
+
+    public function canRateLimit(): bool
+    {
+        return $this->canRateLimitRequests() || $this->canRateLimitComponents();
+    }
+
+    public function canLockout(): bool
+    {
+        return (bool) ( $this->config()->getFeaturesGroupValue('rate_limiting/lockout/enabled') ?? false );
     }
 
     public function isSharedScope(): bool
@@ -50,6 +61,16 @@ class RateLimiterConfig extends ConfigMagewireGroup
     public function getRequestsDecaySeconds(): int
     {
         return (int) ( $this->config()->getFeaturesGroupValue('rate_limiting/requests/decay_seconds') ?? 5 );
+    }
+
+    public function getLockoutWarningThreshold(): int
+    {
+        return max(1, (int) ( $this->config()->getFeaturesGroupValue('rate_limiting/lockout/warning_threshold') ?? 3 ));
+    }
+
+    public function getLockoutSeconds(): int
+    {
+        return max(1, (int) ( $this->config()->getFeaturesGroupValue('rate_limiting/lockout/duration_seconds') ?? 60 ));
     }
 
     protected function getRateLimitingVariant(): string

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/RateLimiterExceptionHandler.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/RateLimiterExceptionHandler.php
@@ -29,6 +29,11 @@ class RateLimiterExceptionHandler extends AbstractExceptionHandler
         if ($exception instanceof TooManyRequestsException) {
             return static function (HttpResponseInterface $response) use ($exception) {
                 $response->setHeader(RequestFilterException::MESSAGE_SEVERITY_HEADER, $exception->severity()->type(), true);
+
+                foreach ($exception->headers() as $name => $value) {
+                    $response->setHeader($name, $value, true);
+                }
+
                 $response->setBody($exception->getMessage());
                 $response->setHttpResponseCode($exception->status());
 

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/Storage/RateLimitLockoutCacheStorage.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/Storage/RateLimitLockoutCacheStorage.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Storage;
+
+use Magento\Framework\Serialize\SerializerInterface;
+use Magewirephp\Magento\App\Cache\Type\Magewire as MagewireCacheType;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimiterStorageInterface;
+
+/**
+ * Stores lockout counters separately per request origin.
+ *
+ * The regular rate limiter keeps all attempt counters in one cache section. A short attempt TTL
+ * must not be able to expire an unrelated, longer lockout, so lockout keys use individual cache
+ * entries instead.
+ */
+class RateLimitLockoutCacheStorage implements RateLimiterStorageInterface
+{
+    private const CACHE_TAG = 'rate_limiter_lockout';
+    private const IDENTIFIER_PREFIX = 'rate-limiter-lockout-';
+
+    public function __construct(
+        private readonly MagewireCacheType $cache,
+        private readonly SerializerInterface $serializer
+    ) {
+    }
+
+    public function get(string $key): array
+    {
+        $data = $this->cache->load($this->identifier($key));
+
+        return is_array($data) ? $data : [];
+    }
+
+    public function set(string $key, array $data, int $ttl): bool
+    {
+        return $this->cache->save($this->serializer->serialize(array_values($data)), $this->identifier($key), [self::CACHE_TAG], max(1, $ttl));
+    }
+
+    public function unset(string $key): bool
+    {
+        return $this->cache->remove($this->identifier($key));
+    }
+
+    private function identifier(string $key): string
+    {
+        return self::IDENTIFIER_PREFIX . hash('sha256', $key);
+    }
+}

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/SupportMagewireRateLimiting.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/SupportMagewireRateLimiting.php
@@ -33,6 +33,7 @@ class SupportMagewireRateLimiting extends ComponentHook
 {
     public function __construct(
         private readonly UpdateRequestRateLimiter $rateLimiter,
+        private readonly RateLimitLockout $lockout,
         private readonly RateLimiterConfig $rateLimiterConfig,
         private readonly ApplicationState $appState
     ) {
@@ -48,17 +49,23 @@ class SupportMagewireRateLimiting extends ComponentHook
         }
 
         if ($this->rateLimiterConfig->canRateLimitComponents()) {
-            on('magewire:component:reconstruct', function () {
+            on('magewire:component:reconstruct', fn () => (
                 // Apply a rate limit check for the component after the component reconstruction.
-                return function (Template $block) {
+                function (Template $block) {
                     $component = $block->getData('magewire');
 
                     // Component scope rate limiting validation.
                     if ($component instanceof Component && ! $this->rateLimiter->validateWithComponent($component)) {
+                        $remainingLockoutSeconds = $this->lockout->registerRejection(UpdateRequestRateLimiter::COMPONENT_DECAY_SECONDS);
+
+                        if ($remainingLockoutSeconds > 0) {
+                            throw TooManyRequestsException::forLockout($remainingLockoutSeconds);
+                        }
+
                         throw new TooManyRequestsException();
                     }
-                };
-            });
+                }
+            ));
         }
     }
 

--- a/lib/Magewire/Features/SupportMagewireRateLimiting/UpdateRequestRateLimiter.php
+++ b/lib/Magewire/Features/SupportMagewireRateLimiting/UpdateRequestRateLimiter.php
@@ -19,6 +19,9 @@ use Magewirephp\Magewire\Mechanisms\HandleRequests\RequestFingerprint;
 
 class UpdateRequestRateLimiter extends RateLimiter
 {
+    public const COMPONENT_MAX_ATTEMPTS = 4;
+    public const COMPONENT_DECAY_SECONDS = 5;
+
     public function __construct(
         private readonly RateLimiterStorageInterface $storage,
         private readonly DateTime $datetime,
@@ -67,7 +70,7 @@ class UpdateRequestRateLimiter extends RateLimiter
          * belongs to the request variant. Both are mutually exclusive, so the original fixed budget
          * is kept here rather than silently adopting values meant for the other variant.
          */
-        return $this->consume($this->generateKeyByComponent($component), 4, 5);
+        return $this->consume($this->generateKeyByComponent($component), self::COMPONENT_MAX_ATTEMPTS, self::COMPONENT_DECAY_SECONDS);
     }
 
     /**

--- a/lib/Magewire/Mechanisms/HandleRequests/Filter/RequestFilterExceptionHandler.php
+++ b/lib/Magewire/Mechanisms/HandleRequests/Filter/RequestFilterExceptionHandler.php
@@ -38,6 +38,11 @@ class RequestFilterExceptionHandler extends AbstractExceptionHandler
 
         return static function (HttpResponseInterface $response) use ($exception) {
             $response->setHeader(RequestFilterException::MESSAGE_SEVERITY_HEADER, $exception->severity()->type(), true);
+
+            foreach ($exception->headers() as $name => $value) {
+                $response->setHeader($name, $value, true);
+            }
+
             $response->setBody($exception->getMessage());
             $response->setHttpResponseCode($exception->status());
 

--- a/src/Controller/Playwright/RateLimiting.php
+++ b/src/Controller/Playwright/RateLimiting.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Controller\Playwright;
+
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magewirephp\Magewire\Controller\MagewireDeveloperAction;
+
+class RateLimiting extends MagewireDeveloperAction implements HttpGetActionInterface
+{
+    protected string $pageTitle = 'Magewire / Playwright / Rate Limiting';
+}

--- a/src/Magewire/Playwright/RateLimiting/Basic.php
+++ b/src/Magewire/Playwright/RateLimiting/Basic.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Magewire\Playwright\RateLimiting;
+
+use Magewirephp\Magewire\Component;
+
+class Basic extends Component
+{
+    public int $count = 0;
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+}

--- a/src/Magewire/Playwright/RateLimiting/PlaywrightRateLimitFilter.php
+++ b/src/Magewire/Playwright/RateLimiting/PlaywrightRateLimitFilter.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Magewire\Playwright\RateLimiting;
+
+use Magento\Framework\App\State as ApplicationState;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Filter\RateLimitFilter;
+use Magewirephp\Magewire\Mechanisms\HandleRequests\Filter\RequestFilterInterface;
+use Magewirephp\Magewire\Mechanisms\HandleRequests\RequestContext;
+use Throwable;
+
+/**
+ * Applies the real rate-limit filter only to the dedicated Playwright component.
+ *
+ * The production filter remains configuration-driven and global. Scoping this delegate by the
+ * verified component snapshot keeps the browser fixture deterministic without throttling other
+ * Playwright specs running against the same store.
+ */
+class PlaywrightRateLimitFilter implements RequestFilterInterface
+{
+    private const COMPONENT_PREFIX = 'magewire.playwright.rate-limiting';
+
+    public function __construct(
+        private readonly RateLimitFilter $rateLimitFilter,
+        private readonly ApplicationState $applicationState
+    ) {
+    }
+
+    public function check(RequestContext $context): void
+    {
+        if ($this->isProduction()) {
+            return;
+        }
+
+        foreach ($context->getComponents() as $componentRequestContext) {
+            $id = (string) $componentRequestContext->getSnapshot()->getMemoValue('id');
+
+            if (str_starts_with($id, self::COMPONENT_PREFIX)) {
+                $this->rateLimitFilter->check($context);
+
+                return;
+            }
+        }
+    }
+
+    private function isProduction(): bool
+    {
+        try {
+            return $this->applicationState->getMode() === ApplicationState::MODE_PRODUCTION;
+        } catch (Throwable) {
+            return true;
+        }
+    }
+}

--- a/src/Magewire/Playwright/RateLimiting/PlaywrightRateLimiterConfig.php
+++ b/src/Magewire/Playwright/RateLimiting/PlaywrightRateLimiterConfig.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Magewire\Playwright\RateLimiting;
+
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimiterConfig;
+
+/**
+ * Fixed policy for the isolated Playwright rate-limiting fixture.
+ */
+class PlaywrightRateLimiterConfig extends RateLimiterConfig
+{
+    public const MAX_ATTEMPTS = 2;
+    public const DECAY_SECONDS = 5;
+    public const WARNING_THRESHOLD = 2;
+    public const LOCKOUT_SECONDS = 6;
+
+    public function throttleInDeveloperMode(): bool
+    {
+        return true;
+    }
+
+    public function canRateLimitRequests(): bool
+    {
+        return true;
+    }
+
+    public function canRateLimitComponents(): bool
+    {
+        return false;
+    }
+
+    public function canLockout(): bool
+    {
+        return true;
+    }
+
+    public function isSharedScope(): bool
+    {
+        return true;
+    }
+
+    public function isIsolatedScope(): bool
+    {
+        return false;
+    }
+
+    public function getRequestsMaxAttempts(): int
+    {
+        return self::MAX_ATTEMPTS;
+    }
+
+    public function getRequestsDecaySeconds(): int
+    {
+        return self::DECAY_SECONDS;
+    }
+
+    public function getLockoutWarningThreshold(): int
+    {
+        return self::WARNING_THRESHOLD;
+    }
+
+    public function getLockoutSeconds(): int
+    {
+        return self::LOCKOUT_SECONDS;
+    }
+}

--- a/src/Magewire/Playwright/RateLimiting/PlaywrightRequestFingerprint.php
+++ b/src/Magewire/Playwright/RateLimiting/PlaywrightRequestFingerprint.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Magewire\Playwright\RateLimiting;
+
+use Magewirephp\Magewire\Mechanisms\HandleRequests\RequestFingerprint;
+
+/**
+ * Keeps fixture counters separate from an administrator-enabled production policy.
+ */
+class PlaywrightRequestFingerprint extends RequestFingerprint
+{
+    public function __construct(
+        private readonly RequestFingerprint $requestFingerprint
+    ) {
+    }
+
+    public function resolve(): string
+    {
+        return 'playwright-rate-limiting@' . $this->requestFingerprint->resolve();
+    }
+}

--- a/src/etc/adminhtml/system/magewire/features/support-rate-limiting/support-rate-limiting.xml
+++ b/src/etc/adminhtml/system/magewire/features/support-rate-limiting/support-rate-limiting.xml
@@ -95,5 +95,64 @@
                 <validate>required-entry integer</validate>
             </field>
         </group>
+
+        <group id="lockout"
+               translate="label comment"
+               sortOrder="30"
+               showInDefault="1"
+               showInWebsite="1"
+               showInStore="1"
+        >
+            <label>Lockout</label>
+            <comment>Optionally escalate repeated rate-limit warnings into a temporary lockout for the same visitor.</comment>
+
+            <field id="enabled"
+                   translate="label comment"
+                   type="select"
+                   sortOrder="10"
+                   showInDefault="1"
+                   showInWebsite="1"
+                   showInStore="1"
+            >
+                <label>Enable Lockout</label>
+                <comment>When enabled, repeated rate-limit warnings temporarily block the visitor and notify them for how long.</comment>
+
+                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            </field>
+
+            <field id="warning_threshold"
+                   translate="label comment"
+                   type="text"
+                   sortOrder="20"
+                   showInDefault="1"
+                   showInWebsite="1"
+                   showInStore="1"
+            >
+                <label>Warnings Before Lockout</label>
+                <comment>Number of rate-limit rejections within the active rate-limit window that trigger a lockout.</comment>
+                <validate>required-entry integer validate-greater-than-zero</validate>
+
+                <depends>
+                    <field id="enabled">1</field>
+                </depends>
+            </field>
+
+            <field id="duration_seconds"
+                   translate="label comment"
+                   type="text"
+                   sortOrder="30"
+                   showInDefault="1"
+                   showInWebsite="1"
+                   showInStore="1"
+            >
+                <label>Lockout Seconds</label>
+                <comment>Number of seconds the visitor remains locked out after reaching the warning threshold.</comment>
+                <validate>required-entry integer validate-greater-than-zero</validate>
+
+                <depends>
+                    <field id="enabled">1</field>
+                </depends>
+            </field>
+        </group>
     </group>
 </include>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -6,7 +6,7 @@
         <magewire>
             <features>
                 <rate_limiting>
-                    <enabled>0</enabled>
+                    <variant>0</variant>
                     <developer_mode>0</developer_mode>
 
                     <requests>
@@ -14,6 +14,12 @@
                         <max_attempts>4</max_attempts>
                         <decay_seconds>5</decay_seconds>
                     </requests>
+
+                    <lockout>
+                        <enabled>0</enabled>
+                        <warning_threshold>3</warning_threshold>
+                        <duration_seconds>60</duration_seconds>
+                    </lockout>
                 </rate_limiting>
             </features>
         </magewire>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -32,6 +32,13 @@
     <preference for="Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimiterStorageInterface"
                 type="Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Storage\RateLimiterCacheStorage"
     />
+    <type name="Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimitLockout">
+        <arguments>
+            <argument name="storage" xsi:type="object">
+                Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Storage\RateLimitLockoutCacheStorage
+            </argument>
+        </arguments>
+    </type>
 
     <!--
         Feature: Magewire View Model

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -257,11 +257,75 @@
         costlier filter reaches out to an external service. Bind a matching exception handler in
         the ExceptionManager pool below to control the HTTP status a rejection responds with.
     -->
+    <virtualType name="Magewirephp\Magewire\Magewire\Playwright\RateLimiting\ConfiguredUpdateRequestRateLimiter"
+                 type="Magewirephp\Magewire\Features\SupportMagewireRateLimiting\UpdateRequestRateLimiter"
+    >
+        <arguments>
+            <argument name="storage" xsi:type="object">
+                Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Storage\RateLimitLockoutCacheStorage
+            </argument>
+            <argument name="rateLimiterConfig" xsi:type="object">
+                Magewirephp\Magewire\Magewire\Playwright\RateLimiting\PlaywrightRateLimiterConfig
+            </argument>
+            <argument name="requestFingerprint" xsi:type="object">
+                Magewirephp\Magewire\Magewire\Playwright\RateLimiting\PlaywrightRequestFingerprint
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="Magewirephp\Magewire\Magewire\Playwright\RateLimiting\ConfiguredRateLimitLockout"
+                 type="Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimitLockout"
+    >
+        <arguments>
+            <argument name="storage" xsi:type="object">
+                Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Storage\RateLimitLockoutCacheStorage
+            </argument>
+            <argument name="config" xsi:type="object">
+                Magewirephp\Magewire\Magewire\Playwright\RateLimiting\PlaywrightRateLimiterConfig
+            </argument>
+            <argument name="requestFingerprint" xsi:type="object">
+                Magewirephp\Magewire\Magewire\Playwright\RateLimiting\PlaywrightRequestFingerprint
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="Magewirephp\Magewire\Magewire\Playwright\RateLimiting\ConfiguredRateLimitFilter"
+                 type="Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Filter\RateLimitFilter"
+    >
+        <arguments>
+            <argument name="rateLimiter" xsi:type="object">
+                Magewirephp\Magewire\Magewire\Playwright\RateLimiting\ConfiguredUpdateRequestRateLimiter
+            </argument>
+            <argument name="lockout" xsi:type="object">
+                Magewirephp\Magewire\Magewire\Playwright\RateLimiting\ConfiguredRateLimitLockout
+            </argument>
+            <argument name="rateLimiterConfig" xsi:type="object">
+                Magewirephp\Magewire\Magewire\Playwright\RateLimiting\PlaywrightRateLimiterConfig
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <type name="Magewirephp\Magewire\Magewire\Playwright\RateLimiting\PlaywrightRateLimitFilter">
+        <arguments>
+            <argument name="rateLimitFilter" xsi:type="object">
+                Magewirephp\Magewire\Magewire\Playwright\RateLimiting\ConfiguredRateLimitFilter
+            </argument>
+        </arguments>
+    </type>
+
     <type name="Magewirephp\Magewire\Mechanisms\HandleRequests\Filter\RequestFilterPipeline">
         <arguments>
             <argument name="filters" xsi:type="array">
                 <item name="rate_limit" xsi:type="object" sortOrder="100">
                     Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Filter\RateLimitFilter
+                </item>
+
+                <!--
+                    Test-only. Delegates the dedicated rate-limiting fixture to the real filter
+                    with an isolated fixed policy. Dormant outside developer mode.
+                -->
+                <item name="playwright_rate_limit" xsi:type="object" sortOrder="800">
+                    Magewirephp\Magewire\Magewire\Playwright\RateLimiting\PlaywrightRateLimitFilter
                 </item>
 
                 <!--

--- a/src/view/base/templates/magewire-features/support-magewire-request-filters/support-magewire-request-filters.phtml
+++ b/src/view/base/templates/magewire-features/support-magewire-request-filters/support-magewire-request-filters.phtml
@@ -21,8 +21,58 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
     document.addEventListener('magewire:init', event => {
         const addons = window.MagewireAddons;
         const header = '<?= $escaper->escapeJs(RequestFilterException::MESSAGE_SEVERITY_HEADER) ?>';
+        const retryAfterHeader = 'Retry-After';
+        const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
+            ?? document.querySelector('[data-csrf]')?.getAttribute('data-csrf')
+            ?? window.livewireScriptConfig?.csrf
+            ?? 'anonymous';
+        const lockoutStorageKey = `magewire:request-filter:lockout:${csrf}`;
+        let lockoutUntil = 0;
 
-        Magewire.hook('request', ({ respond, fail }) => {
+        const readLockoutUntil = () => {
+            try {
+                return Math.max(lockoutUntil, Number.parseInt(localStorage.getItem(lockoutStorageKey), 10) || 0);
+            } catch {
+                return lockoutUntil;
+            }
+        };
+
+        const writeLockoutUntil = deadline => {
+            lockoutUntil = deadline;
+
+            try {
+                localStorage.setItem(lockoutStorageKey, deadline.toString());
+            } catch {
+                // The in-memory deadline still protects this page when storage is unavailable.
+            }
+        };
+
+        const clearLockout = () => {
+            lockoutUntil = 0;
+
+            try {
+                localStorage.removeItem(lockoutStorageKey);
+            } catch {
+                // Nothing else is needed when storage is unavailable.
+            }
+        };
+
+        Magewire.hook('request', ({ options, respond, fail }) => {
+            const deadline = readLockoutUntil();
+
+            if (Date.now() < deadline) {
+                const controller = new AbortController();
+
+                controller.abort();
+                options.signal = controller.signal;
+
+                return;
+            }
+
+            if (deadline !== 0) {
+                clearLockout();
+            }
+
             let severity = null;
 
             respond(({ response }) => {
@@ -33,6 +83,12 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
                  * rejection deserves.
                  */
                 severity = response.headers.get(header);
+
+                const retryAfter = Number.parseInt(response.headers.get(retryAfterHeader), 10);
+
+                if (response.status === 429 && Number.isInteger(retryAfter) && retryAfter > 0) {
+                    writeLockoutUntil(Math.max(readLockoutUntil(), Date.now() + (retryAfter * 1000)));
+                }
             });
 
             fail(({ content, preventDefault }) => {

--- a/src/view/base/templates/magewire-features/support-magewire-request-filters/support-magewire-request-filters.phtml
+++ b/src/view/base/templates/magewire-features/support-magewire-request-filters/support-magewire-request-filters.phtml
@@ -76,12 +76,12 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
             let severity = null;
 
             respond(({ response }) => {
-                /*
+                <?php /*
                  * Presence of the header is the server saying this body was written for the
                  * customer, and its value says how much that message weighs. Status is
                  * deliberately not consulted: a filter decides for itself which status its
                  * rejection deserves.
-                 */
+                 */ ?>
                 severity = response.headers.get(header);
 
                 const retryAfter = Number.parseInt(response.headers.get(retryAfterHeader), 10);
@@ -92,11 +92,11 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
             });
 
             fail(({ content, preventDefault }) => {
-                /*
+                <?php /*
                  * Anything without the header is left to Magewire's regular failure handling,
                  * which renders its own exception output, so a stack trace or an error page can
                  * never reach a customer.
-                 */
+                 */ ?>
                 if (! severity) {
                     return;
                 }
@@ -107,11 +107,11 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
                     return;
                 }
 
-                /*
+                <?php /*
                  * Which UX carries the message is a frontend decision, not something the server
                  * dictates. Swapping the notifier for a modal or an inline banner is a change
                  * here alone.
-                 */
+                 */ ?>
                 if (addons.has('notifier')) {
                     addons.notifier.create(message, { type: severity });
                 } else {

--- a/src/view/frontend/layout/magewire_playwright_ratelimiting.xml
+++ b/src/view/frontend/layout/magewire_playwright_ratelimiting.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd"
+      layout="1column"
+>
+    <body>
+        <referenceContainer name="content">
+            <container name="magewire.playwright.rate-limiting"
+                       htmlId="magewire-playwright-rate-limiting"
+                       htmlTag="div"
+            >
+                <!-- The filter keys on this block name, so renaming it detaches the fixture. -->
+                <block name="magewire.playwright.rate-limiting.basic"
+                       template="Magewirephp_Magewire::tests/magewire/playwright/rate_limiting/basic.phtml"
+                >
+                    <arguments>
+                        <argument name="magewire" xsi:type="object" shared="false">
+                            Magewirephp\Magewire\Magewire\Playwright\RateLimiting\Basic
+                        </argument>
+                    </arguments>
+                </block>
+            </container>
+        </referenceContainer>
+    </body>
+</page>

--- a/src/view/frontend/templates/tests/magewire/playwright/rate_limiting/basic.phtml
+++ b/src/view/frontend/templates/tests/magewire/playwright/rate_limiting/basic.phtml
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+use Magewirephp\Magewire\Magewire\Playwright\RateLimiting\Basic;
+
+/** @var Basic $magewire */
+?>
+<div>
+    <h2 class="text-lg mb-2 font-bold">Rate limiting</h2>
+
+    <p data-testid="rate-limiting-count"><?= (int) $magewire->count ?></p>
+
+    <button type="button" data-testid="rate-limiting-increment" wire:click="increment">Increment</button>
+</div>

--- a/tests/Playwright/tests/rate-limiting.spec.js
+++ b/tests/Playwright/tests/rate-limiting.spec.js
@@ -9,8 +9,8 @@ import { test, expect } from '@playwright/test';
 const PATH = '/magewire/playwright/ratelimiting';
 const UPDATE_URL = '/magewire/update';
 const SEVERITY_HEADER = 'x-magewire-message-severity';
+const RETRY_AFTER_HEADER = 'retry-after';
 const REGULAR_WARNING = 'Too many requests! Please wait.';
-const LOCKOUT_PATTERN = /^You have been temporarily locked out due to too many requests\. Try again in [1-6] seconds\.$/;
 
 const TESTID = {
     count: 'rate-limiting-count',
@@ -29,6 +29,26 @@ async function clickAndCaptureUpdate(page) {
     return response;
 }
 
+async function clickAndAssertNoUpdate(page) {
+    let requests = 0;
+    const countRequest = request => {
+        if (request.url().includes(UPDATE_URL)) {
+            requests++;
+        }
+    };
+
+    page.on('request', countRequest);
+
+    try {
+        await testid(page, TESTID.increment).click();
+        await page.waitForTimeout(250);
+    } finally {
+        page.off('request', countRequest);
+    }
+
+    expect(requests).toBe(0);
+}
+
 async function consumeBudget(page) {
     for (const count of ['1', '2']) {
         const response = await clickAndCaptureUpdate(page);
@@ -43,6 +63,7 @@ async function rejectAtLimit(page) {
 
     expect(response.status()).toBe(429);
     expect(response.headers()[SEVERITY_HEADER]).toBe('warning');
+    expect(response.headers()).not.toHaveProperty(RETRY_AFTER_HEADER);
     expect(await response.text()).toBe(REGULAR_WARNING);
     await expect(testid(page, TESTID.count)).toHaveText('2');
 
@@ -54,6 +75,7 @@ async function triggerLockout(page) {
 
     expect(response.status()).toBe(429);
     expect(response.headers()[SEVERITY_HEADER]).toBe('warning');
+    expect(response.headers()[RETRY_AFTER_HEADER]).toBe('6');
     expect(await response.text()).toBe('You have been temporarily locked out due to too many requests. Try again in 6 seconds.');
     await expect(testid(page, TESTID.count)).toHaveText('2');
 
@@ -77,17 +99,18 @@ test.describe('Magewire Playwright — Rate Limiting', () => {
         await expect(notificationOf(page, 'warning')).toHaveText(REGULAR_WARNING);
     });
 
-    test('escalates repeated rate-limit warnings into an active lockout', async ({ page }) => {
+    test('prevents another browser request while the lockout is active, including after reload', async ({ page }) => {
         await consumeBudget(page);
         await rejectAtLimit(page);
         await triggerLockout(page);
 
-        const response = await clickAndCaptureUpdate(page);
-
-        expect(response.status()).toBe(429);
-        expect(response.headers()[SEVERITY_HEADER]).toBe('warning');
-        expect(await response.text()).toMatch(LOCKOUT_PATTERN);
+        await clickAndAssertNoUpdate(page);
         await expect(testid(page, TESTID.count)).toHaveText('2');
+
+        await page.reload();
+        await expect(testid(page, TESTID.count)).toHaveText('0');
+        await clickAndAssertNoUpdate(page);
+        await expect(testid(page, TESTID.count)).toHaveText('0');
     });
 
     test('accepts requests again after the lockout expires', async ({ page }) => {

--- a/tests/Playwright/tests/rate-limiting.spec.js
+++ b/tests/Playwright/tests/rate-limiting.spec.js
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * End-to-end coverage for the real request limiter and lockout path. A developer-only filter
+ * scopes the fixed test policy to this fixture's component snapshot, so these requests cannot
+ * consume the budgets of other Playwright specs running against the same Magento store.
+ */
+
+const PATH = '/magewire/playwright/ratelimiting';
+const UPDATE_URL = '/magewire/update';
+const SEVERITY_HEADER = 'x-magewire-message-severity';
+const REGULAR_WARNING = 'Too many requests! Please wait.';
+const LOCKOUT_PATTERN = /^You have been temporarily locked out due to too many requests\. Try again in [1-6] seconds\.$/;
+
+const TESTID = {
+    count: 'rate-limiting-count',
+    increment: 'rate-limiting-increment',
+};
+
+const testid = (page, id) => page.locator(`[data-testid="${id}"]`);
+const notificationOf = (page, severity) => page.locator(`.message.${severity} .magewire-notifier-message`);
+
+async function clickAndCaptureUpdate(page) {
+    const [response] = await Promise.all([
+        page.waitForResponse(response => response.url().includes(UPDATE_URL)),
+        testid(page, TESTID.increment).click(),
+    ]);
+
+    return response;
+}
+
+async function consumeBudget(page) {
+    for (const count of ['1', '2']) {
+        const response = await clickAndCaptureUpdate(page);
+
+        expect(response.status()).toBe(200);
+        await expect(testid(page, TESTID.count)).toHaveText(count);
+    }
+}
+
+async function rejectAtLimit(page) {
+    const response = await clickAndCaptureUpdate(page);
+
+    expect(response.status()).toBe(429);
+    expect(response.headers()[SEVERITY_HEADER]).toBe('warning');
+    expect(await response.text()).toBe(REGULAR_WARNING);
+    await expect(testid(page, TESTID.count)).toHaveText('2');
+
+    return response;
+}
+
+async function triggerLockout(page) {
+    const response = await clickAndCaptureUpdate(page);
+
+    expect(response.status()).toBe(429);
+    expect(response.headers()[SEVERITY_HEADER]).toBe('warning');
+    expect(await response.text()).toBe('You have been temporarily locked out due to too many requests. Try again in 6 seconds.');
+    await expect(testid(page, TESTID.count)).toHaveText('2');
+
+    return response;
+}
+
+test.describe('Magewire Playwright — Rate Limiting', () => {
+    test.beforeEach(async ({ page }) => {
+        page.on('dialog', dialog => dialog.dismiss().catch(() => {}));
+
+        const version = Math.floor(Math.random() * 1_000_000);
+        await page.goto(`${PATH}?v=${version}`);
+
+        await expect(testid(page, TESTID.count)).toHaveText('0');
+    });
+
+    test('allows the configured request budget before returning 429', async ({ page }) => {
+        await consumeBudget(page);
+        await rejectAtLimit(page);
+
+        await expect(notificationOf(page, 'warning')).toHaveText(REGULAR_WARNING);
+    });
+
+    test('escalates repeated rate-limit warnings into an active lockout', async ({ page }) => {
+        await consumeBudget(page);
+        await rejectAtLimit(page);
+        await triggerLockout(page);
+
+        const response = await clickAndCaptureUpdate(page);
+
+        expect(response.status()).toBe(429);
+        expect(response.headers()[SEVERITY_HEADER]).toBe('warning');
+        expect(await response.text()).toMatch(LOCKOUT_PATTERN);
+        await expect(testid(page, TESTID.count)).toHaveText('2');
+    });
+
+    test('accepts requests again after the lockout expires', async ({ page }) => {
+        test.setTimeout(45_000);
+
+        await consumeBudget(page);
+        await rejectAtLimit(page);
+        await triggerLockout(page);
+
+        await page.waitForTimeout(6_200);
+
+        const response = await clickAndCaptureUpdate(page);
+
+        expect(response.status()).toBe(200);
+        await expect(testid(page, TESTID.count)).toHaveText('3');
+    });
+
+    test('does not lock out a different browser session', async ({ page, browser, baseURL }) => {
+        await consumeBudget(page);
+        await rejectAtLimit(page);
+        await triggerLockout(page);
+
+        const otherContext = await browser.newContext({ baseURL, ignoreHTTPSErrors: true });
+
+        try {
+            const otherPage = await otherContext.newPage();
+            await otherPage.goto(PATH);
+            await expect(testid(otherPage, TESTID.count)).toHaveText('0');
+
+            const response = await clickAndCaptureUpdate(otherPage);
+
+            expect(response.status()).toBe(200);
+            await expect(testid(otherPage, TESTID.count)).toHaveText('1');
+        } finally {
+            await otherContext.close();
+        }
+    });
+});

--- a/tests/Unit/Features/SupportMagewireRateLimiting/RateLimitFilterTest.php
+++ b/tests/Unit/Features/SupportMagewireRateLimiting/RateLimitFilterTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit\Features\SupportMagewireRateLimiting;
+
+use Magento\Framework\App\State as ApplicationState;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Exceptions\TooManyRequestsException;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Filter\RateLimitFilter;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimiterConfig;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimitLockout;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\UpdateRequestRateLimiter;
+use Magewirephp\Magewire\Mechanisms\HandleRequests\RequestContext;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class RateLimitFilterTest extends TestCase
+{
+    public function test_an_active_lockout_rejects_before_the_request_budget_is_checked(): void
+    {
+        $rateLimiter = $this->createMock(UpdateRequestRateLimiter::class);
+        $rateLimiter->expects(self::never())->method('validateWithRequestContext');
+        $lockout = $this->createMock(RateLimitLockout::class);
+        $lockout->method('remainingSeconds')->willReturn(42);
+
+        $filter = $this->createFilter($rateLimiter, $lockout);
+
+        $this->expectException(TooManyRequestsException::class);
+        $this->expectExceptionMessage('You have been temporarily locked out due to too many requests. Try again in 42 seconds.');
+
+        $filter->check($this->createStub(RequestContext::class));
+    }
+
+    public function test_a_rate_limit_rejection_starts_a_lockout_at_the_configured_threshold(): void
+    {
+        $rateLimiter = $this->createMock(UpdateRequestRateLimiter::class);
+        $rateLimiter->method('validateWithRequestContext')->willReturn(false);
+        $lockout = $this->createMock(RateLimitLockout::class);
+        $lockout->method('remainingSeconds')->willReturn(0);
+        $lockout->expects(self::once())->method('registerRejection')->with(5)->willReturn(60);
+
+        $filter = $this->createFilter($rateLimiter, $lockout);
+
+        $this->expectException(TooManyRequestsException::class);
+        $this->expectExceptionMessage('You have been temporarily locked out due to too many requests. Try again in 60 seconds.');
+
+        $filter->check($this->createStub(RequestContext::class));
+    }
+
+    public function test_a_rejection_before_the_threshold_keeps_the_regular_warning(): void
+    {
+        $rateLimiter = $this->createMock(UpdateRequestRateLimiter::class);
+        $rateLimiter->method('validateWithRequestContext')->willReturn(false);
+        $lockout = $this->createMock(RateLimitLockout::class);
+        $lockout->method('remainingSeconds')->willReturn(0);
+        $lockout->method('registerRejection')->willReturn(0);
+
+        $filter = $this->createFilter($rateLimiter, $lockout);
+
+        $this->expectException(TooManyRequestsException::class);
+        $this->expectExceptionMessage('Too many requests! Please wait.');
+
+        $filter->check($this->createStub(RequestContext::class));
+    }
+
+    public function test_component_scope_only_checks_for_an_existing_origin_lockout(): void
+    {
+        $rateLimiter = $this->createMock(UpdateRequestRateLimiter::class);
+        $rateLimiter->expects(self::never())->method('validateWithRequestContext');
+        $lockout = $this->createMock(RateLimitLockout::class);
+        $lockout->method('remainingSeconds')->willReturn(0);
+        $config = $this->createStub(RateLimiterConfig::class);
+        $config->method('canRateLimit')->willReturn(true);
+        $config->method('canRateLimitRequests')->willReturn(false);
+
+        $filter = $this->createFilter($rateLimiter, $lockout, $config);
+
+        self::assertNull($filter->check($this->createStub(RequestContext::class)));
+    }
+
+    private function createFilter(
+        MockObject $rateLimiter,
+        MockObject $lockout,
+        RateLimiterConfig|null $config = null
+    ): RateLimitFilter {
+        if ($config === null) {
+            $config = $this->createStub(RateLimiterConfig::class);
+            $config->method('canRateLimit')->willReturn(true);
+            $config->method('canRateLimitRequests')->willReturn(true);
+            $config->method('getRequestsDecaySeconds')->willReturn(5);
+        }
+
+        $applicationState = $this->createStub(ApplicationState::class);
+        $applicationState->method('getMode')->willReturn(ApplicationState::MODE_PRODUCTION);
+
+        return new RateLimitFilter($rateLimiter, $lockout, $config, $applicationState);
+    }
+}

--- a/tests/Unit/Features/SupportMagewireRateLimiting/RateLimitLockoutTest.php
+++ b/tests/Unit/Features/SupportMagewireRateLimiting/RateLimitLockoutTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit\Features\SupportMagewireRateLimiting;
+
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimiterConfig;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimiterStorageInterface;
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimitLockout;
+use Magewirephp\Magewire\Mechanisms\HandleRequests\RequestFingerprint;
+use Magewirephp\Magewire\Tests\Unit\Fixtures\InMemoryRateLimiterStorage;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../Fixtures/InMemoryRateLimiterStorage.php';
+
+class RateLimitLockoutTest extends TestCase
+{
+    public function test_it_locks_the_origin_when_the_warning_threshold_is_reached(): void
+    {
+        $now = 1_000;
+        $storage = new InMemoryRateLimiterStorage();
+        $lockout = $this->createLockout($storage, $now, warningThreshold: 3, durationSeconds: 60);
+
+        self::assertSame(0, $lockout->registerRejection(5));
+        self::assertSame(0, $lockout->registerRejection(5));
+        self::assertSame(60, $lockout->registerRejection(5));
+        self::assertSame(60, $lockout->remainingSeconds());
+    }
+
+    public function test_it_reports_the_remaining_time_and_releases_an_expired_lock(): void
+    {
+        $now = 1_000;
+        $storage = new InMemoryRateLimiterStorage();
+        $lockout = $this->createLockout($storage, $now, warningThreshold: 1, durationSeconds: 60);
+
+        self::assertSame(60, $lockout->registerRejection(5));
+
+        $now = 1_041;
+
+        self::assertSame(19, $lockout->remainingSeconds());
+
+        $now = 1_060;
+
+        self::assertSame(0, $lockout->remainingSeconds());
+        self::assertSame([], $storage->all());
+    }
+
+    public function test_warnings_outside_the_rate_limit_window_do_not_accumulate(): void
+    {
+        $now = 1_000;
+        $storage = new InMemoryRateLimiterStorage();
+        $lockout = $this->createLockout($storage, $now, warningThreshold: 2, durationSeconds: 60);
+
+        self::assertSame(0, $lockout->registerRejection(5));
+
+        $now = 1_006;
+
+        self::assertSame(0, $lockout->registerRejection(5));
+        self::assertSame(0, $lockout->remainingSeconds());
+    }
+
+    public function test_lockouts_are_isolated_by_request_fingerprint(): void
+    {
+        $now = 1_000;
+        $storage = new InMemoryRateLimiterStorage();
+        $first = $this->createLockout($storage, $now, fingerprint: 'first', warningThreshold: 1);
+        $second = $this->createLockout($storage, $now, fingerprint: 'second', warningThreshold: 1);
+
+        self::assertSame(60, $first->registerRejection(5));
+        self::assertSame(60, $first->remainingSeconds());
+        self::assertSame(0, $second->remainingSeconds());
+    }
+
+    public function test_it_does_not_write_state_when_lockouts_are_disabled(): void
+    {
+        $now = 1_000;
+        $storage = new InMemoryRateLimiterStorage();
+        $lockout = $this->createLockout($storage, $now, enabled: false, warningThreshold: 1);
+
+        self::assertSame(0, $lockout->registerRejection(5));
+        self::assertSame(0, $lockout->remainingSeconds());
+        self::assertSame([], $storage->all());
+    }
+
+    /** @mago-expect lint:no-boolean-flag-parameter */
+    private function createLockout(
+        RateLimiterStorageInterface $storage,
+        int &$now,
+        string $fingerprint = 'origin',
+        bool $enabled = true,
+        int $warningThreshold = 3,
+        int $durationSeconds = 60
+    ): RateLimitLockout {
+        $dateTime = $this->createStub(DateTime::class);
+        $dateTime
+            ->method('gmtTimestamp')
+            ->willReturnCallback(static function () use (&$now): int {
+                return $now;
+            });
+
+        $config = $this->createStub(RateLimiterConfig::class);
+        $config->method('canLockout')->willReturn($enabled);
+        $config->method('getLockoutWarningThreshold')->willReturn($warningThreshold);
+        $config->method('getLockoutSeconds')->willReturn($durationSeconds);
+
+        $requestFingerprint = $this->createStub(RequestFingerprint::class);
+        $requestFingerprint->method('resolve')->willReturn($fingerprint);
+
+        return new RateLimitLockout($storage, $dateTime, $config, $requestFingerprint);
+    }
+}

--- a/tests/Unit/Features/SupportMagewireRateLimiting/TooManyRequestsExceptionTest.php
+++ b/tests/Unit/Features/SupportMagewireRateLimiting/TooManyRequestsExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit\Features\SupportMagewireRateLimiting;
+
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\Exceptions\TooManyRequestsException;
+use PHPUnit\Framework\TestCase;
+
+class TooManyRequestsExceptionTest extends TestCase
+{
+    public function test_a_regular_rejection_has_no_additional_response_headers(): void
+    {
+        self::assertSame([], ( new TooManyRequestsException() )->headers());
+    }
+
+    public function test_a_lockout_carries_its_remaining_duration_as_retry_after(): void
+    {
+        self::assertSame(['Retry-After' => '42'], TooManyRequestsException::forLockout(42)->headers());
+    }
+}

--- a/tests/Unit/Fixtures/InMemoryRateLimiterStorage.php
+++ b/tests/Unit/Fixtures/InMemoryRateLimiterStorage.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit\Fixtures;
+
+use Magewirephp\Magewire\Features\SupportMagewireRateLimiting\RateLimiterStorageInterface;
+
+class InMemoryRateLimiterStorage implements RateLimiterStorageInterface
+{
+    /** @var array<string, array<int, int>> */
+    private array $values = [];
+
+    public function get(string $key): array
+    {
+        return $this->values[$key] ?? [];
+    }
+
+    public function set(string $key, array $data, int $ttl): bool
+    {
+        $this->values[$key] = $data;
+
+        return true;
+    }
+
+    public function unset(string $key): bool
+    {
+        unset($this->values[$key]);
+
+        return true;
+    }
+
+    /** @return array<string, array<int, int>> */
+    public function all(): array
+    {
+        return $this->values;
+    }
+}


### PR DESCRIPTION
## Summary

- add opt-in admin settings for lockout warning thresholds and duration
- track warning and lockout state per opaque request origin with independent cache entries
- return customer-safe HTTP 429 responses with the remaining lockout duration
- expose active lockouts through `Retry-After` and suppress browser updates until expiry, including after reload
- cover the real limiter and lockout path through an isolated developer-only Playwright fixture

## Verification

- PHPUnit: focused rate-limiting suite
- Playwright: 4 focused rate-limiting scenarios, including zero update requests during lockout
- Playwright: 29 related rate-limiting, request-filter, and exception tests with four workers
- Magento dependency-injection compilation
- focused Mago lint/format, JavaScript syntax, XML validation, and diff checks
