### PR TITLE
fix(compiler): start template fragments

### DIFF
--- a/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Template.php
+++ b/lib/Magewire/Mechanisms/HandleCompiling/View/Directive/Template.php
@@ -24,7 +24,7 @@ class Template extends ScopeDirective
     {
         $var = $this->variableScopeStart();
 
-        return "<?php \${$var} = \$__magewire->utils()->fragment()->make()->template(\$block) ?>";
+        return "<?php \${$var} = \$__magewire->utils()->fragment()->make()->template(\$block)->start() ?>";
     }
 
     public function endtemplate(): string

--- a/tests/Unit/Mechanisms/HandleCompiling/View/Directive/TemplateTest.php
+++ b/tests/Unit/Mechanisms/HandleCompiling/View/Directive/TemplateTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Tests\Unit\Mechanisms\HandleCompiling\View\Directive;
+
+use Magewirephp\Magewire\Mechanisms\HandleCompiling\View\Directive\Template;
+use PHPUnit\Framework\TestCase;
+
+class TemplateTest extends TestCase
+{
+    public function test_it_compiles_a_started_template_fragment_scope(): void
+    {
+        $directive = new Template();
+        $opening = $directive->template();
+
+        self::assertMatchesRegularExpression('/^<\?php \$([a-z]+) = \$__magewire->utils\(\)->fragment\(\)->make\(\)->template\(\$block\)->start\(\) \?>$/', $opening);
+
+        preg_match('/\$([a-z]+) =/', $opening, $matches);
+
+        self::assertSame(sprintf('<?php $%s->end() ?>', $matches[1]), $directive->endtemplate());
+    }
+}


### PR DESCRIPTION
## Summary

- start the compiler-injected template fragment before rendering
- cover the generated start/end lifecycle with a unit test

## Testing

- Magewire directive PHPUnit test
- Mago lint and format checks
- PHP 8.2 syntax checks