### PR TITLE
feat(port): WithPagination support

### DIFF
--- a/dist/Features/SupportPagination/HandlesPagination.php
+++ b/dist/Features/SupportPagination/HandlesPagination.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Livewire copyright © Caleb Porzio (https://github.com/livewire/livewire).
+ * Magewire copyright © Willem Poortman 2024-present.
+ * All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+namespace Magewirephp\Magewire\Features\SupportPagination;
+
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Str;
+trait HandlesPagination
+{
+    public $paginators = [];
+    public function queryStringHandlesPagination()
+    {
+        return collect($this->paginators)->mapWithKeys(function ($page, $pageName) {
+            return ['paginators.' . $pageName => ['history' => true, 'as' => $pageName, 'keep' => false]];
+        })->toArray();
+    }
+    public function getPage($pageName = 'page')
+    {
+        return $this->paginators[$pageName] ?? 1;
+    }
+    public function previousPage($pageName = 'page')
+    {
+        $this->setPage(max(($this->paginators[$pageName] ?? 1) - 1, 1), $pageName);
+    }
+    public function nextPage($pageName = 'page')
+    {
+        $this->setPage(($this->paginators[$pageName] ?? 1) + 1, $pageName);
+    }
+    public function gotoPage($page, $pageName = 'page')
+    {
+        $this->setPage($page, $pageName);
+    }
+    public function resetPage($pageName = 'page')
+    {
+        $this->setPage(1, $pageName);
+    }
+    public function setPage($page, $pageName = 'page')
+    {
+        if (is_numeric($page)) {
+            $page = (int) ($page <= 0 ? 1 : $page);
+        }
+        $beforePaginatorMethod = 'updatingPaginators';
+        $afterPaginatorMethod = 'updatedPaginators';
+        $beforeMethod = 'updating' . ucfirst(Str::camel($pageName));
+        $afterMethod = 'updated' . ucfirst(Str::camel($pageName));
+        if (method_exists($this, $beforePaginatorMethod)) {
+            $this->{$beforePaginatorMethod}($page, $pageName);
+        }
+        if (method_exists($this, $beforeMethod)) {
+            $this->{$beforeMethod}($page, null);
+        }
+        $this->paginators[$pageName] = $page;
+        if (method_exists($this, $afterPaginatorMethod)) {
+            $this->{$afterPaginatorMethod}($page, $pageName);
+        }
+        if (method_exists($this, $afterMethod)) {
+            $this->{$afterMethod}($page, null);
+        }
+    }
+}

--- a/dist/Features/SupportPagination/SupportPagination.php
+++ b/dist/Features/SupportPagination/SupportPagination.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Livewire copyright © Caleb Porzio (https://github.com/livewire/livewire).
+ * Magewire copyright © Willem Poortman 2024-present.
+ * All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+namespace Magewirephp\Magewire\Features\SupportPagination;
+
+use function Magewirephp\Magewire\invade;
+use Magewirephp\Magewire\WithPagination;
+use Magewirephp\Magewire\Features\SupportQueryString\SupportQueryString;
+use Magewirephp\Magewire\ComponentHookRegistry;
+use Magewirephp\Magewire\ComponentHook;
+use Magewirephp\Magewire\Livewire;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\Cursor;
+class SupportPagination extends ComponentHook
+{
+    protected $restoreOverriddenPaginationViews;
+    function skip()
+    {
+        return !in_array(WithPagination::class, class_uses_recursive($this->component));
+    }
+}

--- a/dist/Features/SupportPagination/WithoutUrlPagination.php
+++ b/dist/Features/SupportPagination/WithoutUrlPagination.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Livewire copyright © Caleb Porzio (https://github.com/livewire/livewire).
+ * Magewire copyright © Willem Poortman 2024-present.
+ * All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+namespace Magewirephp\Magewire\Features\SupportPagination;
+
+trait WithoutUrlPagination
+{
+    //
+}

--- a/dist/WithPagination.php
+++ b/dist/WithPagination.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Livewire copyright © Caleb Porzio (https://github.com/livewire/livewire).
+ * Magewire copyright © Willem Poortman 2024-present.
+ * All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+namespace Magewirephp\Magewire;
+
+use Magewirephp\Magewire\Features\SupportPagination\HandlesPagination;
+trait WithPagination
+{
+    use HandlesPagination;
+}

--- a/portman.config.php
+++ b/portman.config.php
@@ -12,15 +12,18 @@ return [
                 'glob' => '**/*.php',
                 'ignore' => [
                     '{Wi,Attr,hel,Imp,Form}*',
+                    '!WithPagination.php',
                     'Livewire.php',
                     'Attributes/**/*',
                     '!Attributes/{Locked,On,Lazy}.php',
                     'Drawer/{ImplicitRouteBinding,Regexes}*',
                     'Exceptions/{Event,Livewire,Root}*',
                     'Features/**/*',
-                    '!Features/Support{Attributes,Events,LifecycleHooks,Locales,NestingComponents,Redirects,FormObjects,Validation,LockedProperties,Streaming,LazyLoading,MultipleRootElementDetection}/**/*',
+                    '!Features/Support{Attributes,Events,LifecycleHooks,Locales,NestingComponents,Redirects,FormObjects,Validation,LockedProperties,Streaming,LazyLoading,MultipleRootElementDetection,Pagination}/**/*',
                     'Features/SupportEvents/TestsEvents.php',
                     'Features/SupportRedirects/TestsRedirects.php',
+                    'Features/SupportPagination/{PaginationUrl,BrowserTest,UnitTest}.php',
+                    'Features/SupportPagination/views/**/*',
                     'Mechanisms/CompileLivewireTags/**/*',
                     'Mechanisms/ExtendBlade/**/*',
                     'Mechanisms/HandleComponents/Synthesizers/{Carbon,Collection,Stringable}*',
@@ -106,6 +109,23 @@ return [
                         'redirectAction',
                         'redirectRoute',
                         'redirectIntended'
+                    ]
+                ],
+                'Features\\SupportPagination\\SupportPagination' => [
+                    'remove-methods' => [
+                        'provide',
+                        'boot',
+                        'destroy',
+                        'overrideDefaultPaginationViews',
+                        'setPathResolvers',
+                        'setPageResolvers',
+                        'ensurePaginatorIsInitialized',
+                        'getQueryStringDetails',
+                        'resolvePage',
+                        'addUrlHook',
+                        'paginationView',
+                        'paginationSimpleView',
+                        'getQueryString'
                     ]
                 ]
             ]

--- a/portman/Livewire/Features/SupportPagination/HandlesPagination.php
+++ b/portman/Livewire/Features/SupportPagination/HandlesPagination.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Magewirephp\Magewire\Features\SupportPagination;
+
+trait HandlesPagination
+{
+    public function getPage($pageName = 'page')
+    {
+        return $this->paginators[$pageName] ?? 1;
+    }
+}

--- a/src/Controller/Playwright/Pagination.php
+++ b/src/Controller/Playwright/Pagination.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Controller\Playwright;
+
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magewirephp\Magewire\Controller\MagewireDeveloperAction;
+
+class Pagination extends MagewireDeveloperAction implements HttpGetActionInterface
+{
+    /**
+     * @var string
+     */
+    protected string $pageTitle = 'Magewire / Playwright / Pagination';
+}

--- a/src/Magewire/Playwright/Pagination/Basic.php
+++ b/src/Magewire/Playwright/Pagination/Basic.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Magewire\Playwright\Pagination;
+
+use Magewirephp\Magewire\Component;
+use Magewirephp\Magewire\WithPagination;
+
+class Basic extends Component
+{
+    use WithPagination;
+
+    private const PER_PAGE = 3;
+
+    private const POSTS = [
+        'Post #1',
+        'Post #2',
+        'Post #3',
+        'Post #4',
+        'Post #5',
+        'Post #6',
+        'Post #7',
+        'Post #8',
+        'Post #9',
+    ];
+
+    /**
+     * @var string
+     */
+    public string $pageHookOutput = '';
+
+    /**
+     * @var string
+     */
+    public string $paginatorHookOutput = '';
+
+    /**
+     * Return the posts visible on the current page.
+     *
+     * @return string[]
+     */
+    public function getCurrentPosts(): array
+    {
+        $offset = ((int) $this->getPage() - 1) * self::PER_PAGE;
+
+        return array_slice(self::POSTS, $offset, self::PER_PAGE);
+    }
+
+    /**
+     * Return the final available page.
+     *
+     * @return int
+     */
+    public function getLastPage(): int
+    {
+        return (int) ceil(count(self::POSTS) / self::PER_PAGE);
+    }
+
+    /**
+     * Navigate to the final fixture page.
+     *
+     * @return void
+     */
+    public function goToLastPage(): void
+    {
+        $this->gotoPage($this->getLastPage());
+    }
+
+    /**
+     * Record the paginator-specific lifecycle hook.
+     *
+     * @param int $page
+     * @return void
+     */
+    public function updatedPage(int $page): void
+    {
+        $this->pageHookOutput = sprintf('page-is-set-to-%d', $page);
+    }
+
+    /**
+     * Record the generic paginator lifecycle hook.
+     *
+     * @param int $page
+     * @param string $pageName
+     * @return void
+     */
+    public function updatedPaginators(int $page, string $pageName): void
+    {
+        $this->paginatorHookOutput = sprintf('%s-is-set-to-%d', $pageName, $page);
+    }
+}

--- a/src/Magewire/Playwright/Pagination/Multiple.php
+++ b/src/Magewire/Playwright/Pagination/Multiple.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+namespace Magewirephp\Magewire\Magewire\Playwright\Pagination;
+
+use Magewirephp\Magewire\Component;
+use Magewirephp\Magewire\WithPagination;
+
+class Multiple extends Component
+{
+    use WithPagination;
+
+    private const PER_PAGE = 3;
+
+    private const POSTS = [
+        'Post #1',
+        'Post #2',
+        'Post #3',
+        'Post #4',
+        'Post #5',
+        'Post #6',
+    ];
+
+    private const ITEMS = [
+        'Item #1',
+        'Item #2',
+        'Item #3',
+        'Item #4',
+        'Item #5',
+        'Item #6',
+    ];
+
+    /**
+     * @var string
+     */
+    public string $pageHookOutput = '';
+
+    /**
+     * @var string
+     */
+    public string $itemPageHookOutput = '';
+
+    /**
+     * Return the posts visible on the default paginator page.
+     *
+     * @return string[]
+     */
+    public function getCurrentPosts(): array
+    {
+        return $this->slicePage(self::POSTS, (int) $this->getPage());
+    }
+
+    /**
+     * Return the items visible on the named paginator page.
+     *
+     * @return string[]
+     */
+    public function getCurrentItems(): array
+    {
+        return $this->slicePage(self::ITEMS, (int) $this->getPage('item-page'));
+    }
+
+    /**
+     * Navigate the named item paginator backwards.
+     *
+     * @return void
+     */
+    public function previousItemPage(): void
+    {
+        $this->previousPage('item-page');
+    }
+
+    /**
+     * Navigate the named item paginator forwards.
+     *
+     * @return void
+     */
+    public function nextItemPage(): void
+    {
+        $this->nextPage('item-page');
+    }
+
+    /**
+     * Record the default paginator lifecycle hook.
+     *
+     * @param int $page
+     * @return void
+     */
+    public function updatedPage(int $page): void
+    {
+        $this->pageHookOutput = sprintf('page-is-set-to-%d', $page);
+    }
+
+    /**
+     * Record the kebab-cased paginator lifecycle hook.
+     *
+     * @param int $page
+     * @return void
+     */
+    public function updatedItemPage(int $page): void
+    {
+        $this->itemPageHookOutput = sprintf('item-page-is-set-to-%d', $page);
+    }
+
+    /**
+     * Slice a deterministic fixture data set for a paginator page.
+     *
+     * @param string[] $values
+     * @param int $page
+     * @return string[]
+     */
+    private function slicePage(array $values, int $page): array
+    {
+        $offset = ($page - 1) * self::PER_PAGE;
+
+        return array_slice($values, $offset, self::PER_PAGE);
+    }
+}

--- a/src/etc/adminhtml/di.xml
+++ b/src/etc/adminhtml/di.xml
@@ -183,6 +183,11 @@
                     <item name="sort_order" xsi:type="number">1250</item>
                 </item>
 
+                <item name="pagination" xsi:type="array">
+                    <item name="type" xsi:type="string">Magewirephp\Magewire\Features\SupportPagination\SupportPagination</item>
+                    <item name="sort_order" xsi:type="number">1275</item>
+                </item>
+
                 <item name="redirects" xsi:type="array">
                     <item name="type" xsi:type="string">Magewirephp\Magewire\Features\SupportRedirects\SupportRedirects</item>
                     <item name="sort_order" xsi:type="number">1300</item>

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -171,6 +171,11 @@
                     <item name="sort_order" xsi:type="number">1250</item>
                 </item>
 
+                <item name="pagination" xsi:type="array">
+                    <item name="type" xsi:type="string">Magewirephp\Magewire\Features\SupportPagination\SupportPagination</item>
+                    <item name="sort_order" xsi:type="number">1275</item>
+                </item>
+
                 <item name="redirects" xsi:type="array">
                     <item name="type" xsi:type="string">Magewirephp\Magewire\Features\SupportRedirects\SupportRedirects</item>
                     <item name="sort_order" xsi:type="number">1300</item>

--- a/src/view/frontend/layout/magewire_playwright_pagination.xml
+++ b/src/view/frontend/layout/magewire_playwright_pagination.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd"
+      layout="1column"
+>
+    <body>
+        <referenceContainer name="content">
+            <container name="magewire.playwright.pagination"
+                       htmlClass="grid grid-cols-1 gap-x-8 gap-y-16"
+                       htmlId="magewire-playwright-pagination"
+                       htmlTag="div"
+            >
+                <block name="magewire.playwright.pagination.basic"
+                       template="Magewirephp_Magewire::tests/magewire/playwright/pagination/basic.phtml"
+                >
+                    <arguments>
+                        <argument name="magewire" xsi:type="object" shared="false">
+                            Magewirephp\Magewire\Magewire\Playwright\Pagination\Basic
+                        </argument>
+                    </arguments>
+                </block>
+
+                <block name="magewire.playwright.pagination.multiple"
+                       template="Magewirephp_Magewire::tests/magewire/playwright/pagination/multiple.phtml"
+                >
+                    <arguments>
+                        <argument name="magewire" xsi:type="object" shared="false">
+                            Magewirephp\Magewire\Magewire\Playwright\Pagination\Multiple
+                        </argument>
+                    </arguments>
+                </block>
+            </container>
+        </referenceContainer>
+    </body>
+</page>

--- a/src/view/frontend/templates/tests/magewire/playwright/pagination/basic.phtml
+++ b/src/view/frontend/templates/tests/magewire/playwright/pagination/basic.phtml
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magewirephp\Magewire\Magewire\Playwright\Pagination\Basic;
+
+/** @var Basic $magewire */
+/** @var Escaper $escaper */
+
+$currentPage = (int) $magewire->getPage();
+?>
+<section data-testid="pagination-basic">
+    <h2><?= $escaper->escapeHtml(__('Default paginator')) ?></h2>
+
+    <ol data-testid="basic-posts">
+        <?php foreach ($magewire->getCurrentPosts() as $offset => $post): ?>
+            <?php $postNumber = (($currentPage - 1) * 3) + $offset + 1 ?>
+            <li data-testid="basic-post" wire:key="basic-post-<?= (int) $postNumber ?>">
+                <?= $escaper->escapeHtml($post) ?>
+            </li>
+        <?php endforeach ?>
+    </ol>
+
+    <p data-testid="basic-current-page"><?= (int) $currentPage ?></p>
+    <p data-testid="basic-page-hook"><?= $escaper->escapeHtml($magewire->pageHookOutput) ?></p>
+    <p data-testid="basic-paginator-hook"><?= $escaper->escapeHtml($magewire->paginatorHookOutput) ?></p>
+
+    <nav aria-label="<?= $escaper->escapeHtmlAttr(__('Default paginator controls')) ?>">
+        <button type="button"
+                data-testid="basic-previous"
+                wire:click="previousPage"
+                <?php if ($currentPage === 1): ?>disabled<?php endif ?>
+        >
+            <?= $escaper->escapeHtml(__('Previous')) ?>
+        </button>
+        <button type="button" data-testid="basic-page-three" wire:click="goToLastPage">
+            <?= $escaper->escapeHtml(__('Page 3')) ?>
+        </button>
+        <button type="button" data-testid="basic-reset" wire:click="resetPage">
+            <?= $escaper->escapeHtml(__('Reset')) ?>
+        </button>
+        <button type="button"
+                data-testid="basic-next"
+                wire:click="nextPage"
+                <?php if ($currentPage === $magewire->getLastPage()): ?>disabled<?php endif ?>
+        >
+            <?= $escaper->escapeHtml(__('Next')) ?>
+        </button>
+    </nav>
+</section>

--- a/src/view/frontend/templates/tests/magewire/playwright/pagination/multiple.phtml
+++ b/src/view/frontend/templates/tests/magewire/playwright/pagination/multiple.phtml
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Copyright © Willem Poortman 2021-present. All rights reserved.
+ *
+ * Please read the README and LICENSE files for more
+ * details on copyrights and license information.
+ */
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magewirephp\Magewire\Magewire\Playwright\Pagination\Multiple;
+
+/** @var Multiple $magewire */
+/** @var Escaper $escaper */
+
+$postPage = (int) $magewire->getPage();
+$itemPage = (int) $magewire->getPage('item-page');
+?>
+<section data-testid="pagination-multiple">
+    <h2><?= $escaper->escapeHtml(__('Multiple paginators')) ?></h2>
+
+    <div data-testid="multiple-posts-paginator">
+        <h3><?= $escaper->escapeHtml(__('Posts')) ?></h3>
+        <ol data-testid="multiple-posts">
+            <?php foreach ($magewire->getCurrentPosts() as $offset => $post): ?>
+                <?php $postNumber = (($postPage - 1) * 3) + $offset + 1 ?>
+                <li data-testid="multiple-post" wire:key="multiple-post-<?= (int) $postNumber ?>">
+                    <?= $escaper->escapeHtml($post) ?>
+                </li>
+            <?php endforeach ?>
+        </ol>
+        <p data-testid="multiple-post-page"><?= (int) $postPage ?></p>
+        <p data-testid="multiple-post-hook"><?= $escaper->escapeHtml($magewire->pageHookOutput) ?></p>
+        <button type="button" data-testid="multiple-post-previous" wire:click="previousPage">
+            <?= $escaper->escapeHtml(__('Previous posts')) ?>
+        </button>
+        <button type="button" data-testid="multiple-post-next" wire:click="nextPage">
+            <?= $escaper->escapeHtml(__('Next posts')) ?>
+        </button>
+    </div>
+
+    <div data-testid="multiple-items-paginator">
+        <h3><?= $escaper->escapeHtml(__('Items')) ?></h3>
+        <ol data-testid="multiple-items">
+            <?php foreach ($magewire->getCurrentItems() as $offset => $item): ?>
+                <?php $itemNumber = (($itemPage - 1) * 3) + $offset + 1 ?>
+                <li data-testid="multiple-item" wire:key="multiple-item-<?= (int) $itemNumber ?>">
+                    <?= $escaper->escapeHtml($item) ?>
+                </li>
+            <?php endforeach ?>
+        </ol>
+        <p data-testid="multiple-item-page"><?= (int) $itemPage ?></p>
+        <p data-testid="multiple-item-hook"><?= $escaper->escapeHtml($magewire->itemPageHookOutput) ?></p>
+        <button type="button"
+                data-testid="multiple-item-previous"
+                wire:click="previousItemPage"
+        >
+            <?= $escaper->escapeHtml(__('Previous items')) ?>
+        </button>
+        <button type="button"
+                data-testid="multiple-item-next"
+                wire:click="nextItemPage"
+        >
+            <?= $escaper->escapeHtml(__('Next items')) ?>
+        </button>
+    </div>
+</section>


### PR DESCRIPTION
**What**

Ports Livewire's `WithPagination` to Magewire with a Magento-adapted `SupportPagination` feature.

**How**

- Portman-ported: `WithPagination`, `HandlesPagination`, `WithoutUrlPagination`.
- `SupportPagination` stripped to just `skip()` (via `remove-methods`): Paginator singletons, view overrides and no URL/query-string tracking yet.
- Current page lives in synchronized component state (`$paginators`), not the URL; `getPage()` falls back to `1` instead of `Paginator::resolveCurrentPage()`.
- Hook registered per area (frontend + adminhtml), sort_order `1275`.

**Out of scope** 

URL/query-string pagination; `PaginationUrl`, tests and Blade views excluded.

**Verified** 

Deterministic build (zero drift on existing `dist`); classes resolve and page logic (next/goto/reset, clamp) tested.