### PR TITLE
fix(runtime): add canonical Magewire runtime providers

### DIFF
--- a/src/view/frontend/templates/js/alpinejs/components/magewire-script.phtml
+++ b/src/view/frontend/templates/js/alpinejs/components/magewire-script.phtml
@@ -16,13 +16,13 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
 ?>
 <?php $script = $magewireFragment->make()->script()->start() ?>
 <script>
-    function magewireScript() {
+    function magewireRuntime() {
         return {
             //
         };
     }
 
-    function magewireScriptBindings() {
+    function magewireRuntimeBindings() {
         return {
             'x-bind:data-update-uri'() {
                 return '<?= $escaper->escapeJs($magewireUtility->getUpdateUri()) ?>';
@@ -33,9 +33,27 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
         };
     }
 
+    /**
+     * @deprecated Use magewireRuntime instead.
+     */
+    function magewireScript() {
+        return magewireRuntime();
+    }
+
+    /**
+     * @deprecated Use magewireRuntimeBindings instead.
+     */
+    function magewireScriptBindings() {
+        return magewireRuntimeBindings();
+    }
+
     <?php /* Register as Alpine component. */ ?>
-    document.addEventListener('alpine:init', () => Alpine.data('magewireScript', magewireScript), { once: true })
+    document.addEventListener('alpine:init', () => Alpine.data('magewireRuntime', magewireRuntime), { once: true })
     <?php /* Register Alpine component bindings (for optional usage). */ ?>
+    document.addEventListener('alpine:init', () => Alpine.bind('magewireRuntimeBindings', magewireRuntimeBindings), { once: true });
+    <?php /* Register deprecated Alpine component alias. */ ?>
+    document.addEventListener('alpine:init', () => Alpine.data('magewireScript', magewireScript), { once: true })
+    <?php /* Register deprecated Alpine component bindings alias. */ ?>
     document.addEventListener('alpine:init', () => Alpine.bind('magewireScriptBindings', magewireScriptBindings), { once: true });
 </script>
 <?php $script->end() ?>

--- a/src/view/frontend/templates/js/alpinejs/components/magewire-script.phtml
+++ b/src/view/frontend/templates/js/alpinejs/components/magewire-script.phtml
@@ -33,16 +33,12 @@ $magewireFragment = $magewireViewModel->utils()->fragment();
         };
     }
 
-    /**
-     * @deprecated Use magewireRuntime instead.
-     */
+    <?php /* @deprecated Use magewireRuntime instead. */ ?>
     function magewireScript() {
         return magewireRuntime();
     }
 
-    /**
-     * @deprecated Use magewireRuntimeBindings instead.
-     */
+    <?php /* @deprecated Use magewireRuntimeBindings instead. */ ?>
     function magewireScriptBindings() {
         return magewireRuntimeBindings();
     }

--- a/tests/Playwright/tests/runtime.spec.js
+++ b/tests/Playwright/tests/runtime.spec.js
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+const PATH = '/magewire/playwright/directives';
+
+async function mountRuntimeProbe(page, dataProvider, bindingProvider) {
+    return page.evaluate(({ dataProvider, bindingProvider }) => {
+        const probe = document.createElement('div');
+        probe.setAttribute('x-data', dataProvider);
+        probe.setAttribute('x-bind', bindingProvider);
+        document.body.appendChild(probe);
+
+        window.Alpine.initTree(probe);
+
+        const attributes = {
+            csrf: probe.getAttribute('data-csrf'),
+            updateUri: probe.getAttribute('data-update-uri'),
+        };
+
+        probe.remove();
+
+        return attributes;
+    }, { dataProvider, bindingProvider });
+}
+
+test.describe('Magewire Playwright — Runtime', () => {
+    test.beforeEach(async ({ page }) => {
+        const version = Math.floor(Math.random() * 1_000_000);
+        await page.goto(`${PATH}?v=${version}`);
+        await page.waitForFunction(() => window.Alpine && window.MagewireUtilities);
+    });
+
+    test('registers the canonical runtime providers', async ({ page }) => {
+        const attributes = await mountRuntimeProbe(
+            page,
+            'magewireRuntime',
+            'magewireRuntimeBindings',
+        );
+
+        expect(attributes.csrf).toMatch(/\S/);
+        expect(attributes.updateUri).toMatch(/\/magewire\/update/);
+    });
+
+    test('keeps the deprecated script providers operational', async ({ page }) => {
+        const attributes = await mountRuntimeProbe(
+            page,
+            'magewireScript',
+            'magewireScriptBindings',
+        );
+
+        expect(attributes.csrf).toMatch(/\S/);
+        expect(attributes.updateUri).toMatch(/\/magewire\/update/);
+    });
+});


### PR DESCRIPTION
## Summary

- add magewireRuntime and magewireRuntimeBindings as the canonical Alpine providers
- keep magewireScript and magewireScriptBindings as deprecated delegating aliases
- cover both provider pairs with Playwright regression tests

## Why

These providers carry Magewire runtime configuration, not script behavior. The canonical names align the public API with the magewire-runtime host used by CSP-compatible integrations while preserving existing integrations during migration.

## Verification

- PHP template syntax check
- Mago formatting check for the changed template
- JavaScript syntax check
- Playwright runtime suite: 2 passed
- whitespace validation