### PR TITLE
ci: enable trusted fork test runs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,11 @@ name: 'Playwright (Mage-OS + Hyvä)'
 
 on:
   workflow_call:
+    secrets:
+      HYVA_COMPOSER_REPO_URL:
+        required: true
+      HYVA_COMPOSER_AUTH_TOKEN:
+        required: true
 
 permissions:
   contents: read
@@ -101,6 +106,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: magewire-src
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/portman.yml
+++ b/.github/workflows/portman.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
 
@@ -21,8 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.MY_TOKEN }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.event.pull_request.head.sha }}
+          token: ${{ secrets.MY_TOKEN || github.token }}
+          persist-credentials: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Setup php
         uses: shivammathur/setup-php@v2
@@ -40,6 +41,14 @@ jobs:
       - name: Portman build
         run: ./vendor/bin/portman build
 
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - name: Verify Portman build is committed
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          git add --intent-to-add --all
+          git diff --exit-code
+
+      - name: Commit Portman build
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'chore(portman) build'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,5 +50,12 @@ jobs:
 
   playwright:
     name: 'Playwright'
+    # Fork PRs cannot access the private Hyvä credentials. A maintainer can run
+    # this suite for their exact head SHA by commenting `/test` on the PR.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/playwright.yml
-    secrets: inherit
+    secrets:
+      HYVA_COMPOSER_REPO_URL: ${{ secrets.HYVA_COMPOSER_REPO_URL }}
+      HYVA_COMPOSER_AUTH_TOKEN: ${{ secrets.HYVA_COMPOSER_AUTH_TOKEN }}

--- a/.github/workflows/trusted-fork-tests.yml
+++ b/.github/workflows/trusted-fork-tests.yml
@@ -1,0 +1,125 @@
+name: 'Trusted fork tests'
+
+# Fork pull_request workflows intentionally receive no repository secrets. After
+# reviewing a PR revision, a maintainer can comment `/test` to mirror that exact
+# commit to an internal CI ref and dispatch the complete test workflow there.
+# No contributor code is executed by this privileged broker.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+
+  dispatch:
+    name: 'Dispatch /test'
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/test' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Authorize maintainer and dispatch PR revision
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const actor = context.payload.comment.user.login;
+            const { data: access } = await github.rest.repos.getCollaboratorPermissionLevel({
+              ...context.repo,
+              username: actor,
+            });
+
+            if (!['admin', 'write'].includes(access.permission)) {
+              core.notice(`Ignoring /test from ${actor}: write access is required.`);
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            });
+
+            if (pull.state !== 'open' || !pull.head.repo) {
+              core.setFailed('The pull request must be open and its head repository must be available.');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: pull.number,
+              per_page: 100,
+            });
+            const workflowChanges = files
+              .map(file => file.filename)
+              .filter(filename => filename.startsWith('.github/workflows/'));
+
+            if (workflowChanges.length > 0) {
+              core.setFailed(`Refusing privileged tests because the PR changes workflow files: ${workflowChanges.join(', ')}`);
+              return;
+            }
+
+            const branch = `ci/pr-${pull.number}`;
+            const ref = `heads/${branch}`;
+
+            try {
+              const { data: current } = await github.rest.git.getRef({
+                ...context.repo,
+                ref,
+              });
+
+              if (current.object.sha !== pull.head.sha) {
+                await github.rest.git.updateRef({
+                  ...context.repo,
+                  ref,
+                  sha: pull.head.sha,
+                  force: true,
+                });
+              }
+            } catch (error) {
+              if (error.status !== 404) throw error;
+
+              await github.rest.git.createRef({
+                ...context.repo,
+                ref: `refs/${ref}`,
+                sha: pull.head.sha,
+              });
+            }
+
+            await github.rest.actions.createWorkflowDispatch({
+              ...context.repo,
+              workflow_id: 'tests.yml',
+              ref: branch,
+            });
+
+            core.notice(`Dispatched Tests for PR #${pull.number} at ${pull.head.sha} via ${branch}.`);
+
+  cleanup:
+    name: 'Remove trusted CI ref'
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete temporary PR ref
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const ref = `heads/ci/pr-${context.payload.pull_request.number}`;
+
+            try {
+              await github.rest.git.deleteRef({
+                ...context.repo,
+                ref,
+              });
+            } catch (error) {
+              if (![404, 422].includes(error.status)) throw error;
+              core.notice(`No temporary ref found at ${ref}.`);
+            }

--- a/.github/workflows/trusted-fork-tests.yml
+++ b/.github/workflows/trusted-fork-tests.yml
@@ -9,6 +9,10 @@ on:
     types: [created]
   pull_request_target:
     types: [closed]
+  workflow_run:
+    workflows: ['Tests']
+    types: [completed]
+    branches: ['ci/pr-*-comment-*']
 
 permissions: {}
 
@@ -25,6 +29,7 @@ jobs:
     permissions:
       actions: write
       contents: write
+      issues: write
       pull-requests: read
     steps:
       - name: Authorize maintainer and dispatch PR revision
@@ -52,6 +57,16 @@ jobs:
               return;
             }
 
+            const commentId = context.payload.comment.id;
+            const shortSha = pull.head.sha.slice(0, 7);
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${pull.head.sha}`;
+            const brokerUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const updateComment = body => github.rest.issues.updateComment({
+              ...context.repo,
+              comment_id: commentId,
+              body,
+            });
+
             const files = await github.paginate(github.rest.pulls.listFiles, {
               ...context.repo,
               pull_number: pull.number,
@@ -62,44 +77,120 @@ jobs:
               .filter(filename => filename.startsWith('.github/workflows/'));
 
             if (workflowChanges.length > 0) {
+              await updateComment([
+                '### Trusted fork tests',
+                '',
+                `⛔ Tests were not started for [\`${shortSha}\`](${commitUrl}) because this PR changes GitHub Actions workflow files.`,
+                '',
+                'Privileged testing requires those workflow changes to be reviewed and merged separately.',
+                '',
+                `[View authorization details](${brokerUrl})`,
+              ].join('\n'));
               core.setFailed(`Refusing privileged tests because the PR changes workflow files: ${workflowChanges.join(', ')}`);
               return;
             }
 
-            const branch = `ci/pr-${pull.number}`;
+            const branch = `ci/pr-${pull.number}-comment-${commentId}`;
             const ref = `heads/${branch}`;
 
             try {
-              const { data: current } = await github.rest.git.getRef({
-                ...context.repo,
-                ref,
-              });
-
-              if (current.object.sha !== pull.head.sha) {
-                await github.rest.git.updateRef({
+              try {
+                const { data: current } = await github.rest.git.getRef({
                   ...context.repo,
                   ref,
+                });
+
+                if (current.object.sha !== pull.head.sha) {
+                  throw new Error(`${branch} already points to a different revision.`);
+                }
+              } catch (error) {
+                if (error.status !== 404) throw error;
+
+                await github.rest.git.createRef({
+                  ...context.repo,
+                  ref: `refs/${ref}`,
                   sha: pull.head.sha,
-                  force: true,
                 });
               }
-            } catch (error) {
-              if (error.status !== 404) throw error;
 
-              await github.rest.git.createRef({
+              const runsUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/tests.yml?query=${encodeURIComponent(`branch:${branch}`)}`;
+              await updateComment([
+                '### Trusted fork tests',
+                '',
+                `⏳ Tests are running for [\`${shortSha}\`](${commitUrl}).`,
+                '',
+                `[View workflow runs](${runsUrl})`,
+              ].join('\n'));
+
+              await github.rest.actions.createWorkflowDispatch({
                 ...context.repo,
-                ref: `refs/${ref}`,
-                sha: pull.head.sha,
+                workflow_id: 'tests.yml',
+                ref: branch,
               });
+
+              core.notice(`Dispatched Tests for PR #${pull.number} at ${pull.head.sha} via ${branch}.`);
+            } catch (error) {
+              await updateComment([
+                '### Trusted fork tests',
+                '',
+                `❌ Tests could not be started for [\`${shortSha}\`](${commitUrl}).`,
+                '',
+                `[Review the authorization run](${brokerUrl}), then add a new \`/test\` comment to try again.`,
+              ].join('\n'));
+              throw error;
             }
 
-            await github.rest.actions.createWorkflowDispatch({
-              ...context.repo,
-              workflow_id: 'tests.yml',
-              ref: branch,
-            });
+  report:
+    name: 'Report trusted result'
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
+      startsWith(github.event.workflow_run.head_branch, 'ci/pr-')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Update command comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const match = /^ci\/pr-(\d+)-comment-(\d+)$/.exec(run.head_branch);
 
-            core.notice(`Dispatched Tests for PR #${pull.number} at ${pull.head.sha} via ${branch}.`);
+            if (!match) {
+              core.notice(`Ignoring unrecognized trusted CI ref ${run.head_branch}.`);
+              return;
+            }
+
+            const commentId = Number(match[2]);
+            const shortSha = run.head_sha.slice(0, 7);
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${run.head_sha}`;
+            let summary;
+
+            if (run.conclusion === 'success') {
+              summary = `✅ All trusted tests passed for [\`${shortSha}\`](${commitUrl}).`;
+            } else if (run.conclusion === 'cancelled') {
+              summary = `⚠️ Trusted tests were cancelled for [\`${shortSha}\`](${commitUrl}). Add a new \`/test\` comment to run them again.`;
+            } else {
+              summary = `❌ Trusted tests failed for [\`${shortSha}\`](${commitUrl}). Review the failure, then add a new \`/test\` comment to rerun them.`;
+            }
+
+            try {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: commentId,
+                body: [
+                  '### Trusted fork tests',
+                  '',
+                  summary,
+                  '',
+                  `[View workflow run](${run.html_url})`,
+                ].join('\n'),
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              core.notice(`Command comment ${commentId} no longer exists.`);
+            }
 
   cleanup:
     name: 'Remove trusted CI ref'
@@ -112,14 +203,18 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const ref = `heads/ci/pr-${context.payload.pull_request.number}`;
+            const prefix = `heads/ci/pr-${context.payload.pull_request.number}-comment-`;
+            const refs = await github.paginate(github.rest.git.listMatchingRefs, {
+              ...context.repo,
+              ref: prefix,
+              per_page: 100,
+            });
 
-            try {
+            for (const reference of refs) {
               await github.rest.git.deleteRef({
                 ...context.repo,
-                ref,
+                ref: reference.ref.replace(/^refs\//, ''),
               });
-            } catch (error) {
-              if (![404, 422].includes(error.status)) throw error;
-              core.notice(`No temporary ref found at ${ref}.`);
             }
+
+            core.notice(`Removed ${refs.length} temporary ref(s) matching ${prefix}.`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,8 @@ Release-please uses these to cut version bumps and generate `CHANGELOG.md`.
 3. Update or add a skill under `.claude/skills/` if your change alters a documented API or pattern.
 4. Include a description explaining **why**, not just **what** — the diff shows the what.
 5. Link relevant discussions or issues.
-6. CI will re-run `portman build` on your PR and auto-commit `dist/` changes, so you don't need to include `dist/` diffs if you don't want to. But committing them locally first avoids conflicts.
+6. CI will re-run `portman build` on your PR. Same-repository branches receive an automatic `dist/` commit; fork PRs must include the generated changes themselves.
+7. Fork PRs run all public checks without repository secrets. After reviewing the code, a maintainer can comment `/test` to run the private Hyvä Playwright suite against that exact PR revision.
 
 ### What gets rejected
 


### PR DESCRIPTION
## Summary

- keep fork PR checks read-only and skip the secret-dependent Playwright job
- let maintainers comment /test to mirror the exact reviewed SHA to a unique internal CI ref and dispatch the complete Tests workflow
- update the command comment while tests are running and when they pass, fail, or are cancelled
- reject privileged dispatches when a PR changes workflow files
- make Portman verify generated output on forks while preserving same-repository auto-commits
- pass only the two required Hyva credentials to Playwright
- remove temporary CI refs when PRs close

## Trust model

The broker runs from the default branch and executes no contributor code. It verifies that the commenter has write access before creating the internal ref. Each run is bound to the initiating comment and exact PR SHA. The dispatched test suite does execute the reviewed PR revision with the Hyva credentials, so maintainers must inspect the revision before commenting /test.

The completion reporter uses workflow_run only to update the original command comment. It does not check out or execute PR code.

## Verification

- Actionlint 1.7.12 across every workflow
- YAML parse validation
- JavaScript syntax validation for embedded github-script blocks
- git diff --check
- read-only validation against fork PR #292 and its exact head SHA

## Test after merge

Post a new /test comment on #292. The earlier comment cannot trigger retroactively.

Refs #292