### PR TITLE
fix(ci): use bot-owned test status comment

### DIFF
--- a/.github/workflows/trusted-fork-tests.yml
+++ b/.github/workflows/trusted-fork-tests.yml
@@ -57,13 +57,12 @@ jobs:
               return;
             }
 
-            const commentId = context.payload.comment.id;
             const shortSha = pull.head.sha.slice(0, 7);
             const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${pull.head.sha}`;
             const brokerUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const updateComment = body => github.rest.issues.updateComment({
+            const createStatusComment = body => github.rest.issues.createComment({
               ...context.repo,
-              comment_id: commentId,
+              issue_number: pull.number,
               body,
             });
 
@@ -77,7 +76,7 @@ jobs:
               .filter(filename => filename.startsWith('.github/workflows/'));
 
             if (workflowChanges.length > 0) {
-              await updateComment([
+              await createStatusComment([
                 '### Trusted fork tests',
                 '',
                 `⛔ Tests were not started for [\`${shortSha}\`](${commitUrl}) because this PR changes GitHub Actions workflow files.`,
@@ -90,8 +89,18 @@ jobs:
               return;
             }
 
-            const branch = `ci/pr-${pull.number}-comment-${commentId}`;
+            const { data: statusComment } = await createStatusComment([
+              '### Trusted fork tests',
+              '',
+              `⏳ Preparing trusted tests for [\`${shortSha}\`](${commitUrl}).`,
+            ].join('\n'));
+            const branch = `ci/pr-${pull.number}-comment-${statusComment.id}`;
             const ref = `heads/${branch}`;
+            const updateStatusComment = body => github.rest.issues.updateComment({
+              ...context.repo,
+              comment_id: statusComment.id,
+              body,
+            });
 
             try {
               try {
@@ -114,7 +123,7 @@ jobs:
               }
 
               const runsUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/tests.yml?query=${encodeURIComponent(`branch:${branch}`)}`;
-              await updateComment([
+              await updateStatusComment([
                 '### Trusted fork tests',
                 '',
                 `⏳ Tests are running for [\`${shortSha}\`](${commitUrl}).`,
@@ -130,7 +139,7 @@ jobs:
 
               core.notice(`Dispatched Tests for PR #${pull.number} at ${pull.head.sha} via ${branch}.`);
             } catch (error) {
-              await updateComment([
+              await updateStatusComment([
                 '### Trusted fork tests',
                 '',
                 `❌ Tests could not be started for [\`${shortSha}\`](${commitUrl}).`,
@@ -150,7 +159,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Update command comment
+      - name: Update status comment
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Cause

[Trusted run 34209876860](https://github.com/magewirephp/magewire/actions/runs/34209876860) received `403 Resource not accessible by integration` when it tried to edit the human-authored `/test` comment. The workflow token had `issues: write`, but GitHub Apps cannot edit a comment owned by another user.

## Fix

- Leave the maintainer `/test` command intact as the authorization record.
- Create a bot-owned status reply before dispatch.
- Update that reply while tests are running and after they succeed, fail, or are cancelled.
- Continue binding the temporary CI ref to the exact tested commit and status-comment ID.

## Verification

- `actionlint .github/workflows/trusted-fork-tests.yml`
- YAML parse
- Embedded `github-script` JavaScript syntax check
- `git diff --check`

After merge, add a new `/test` comment to PR #292 to exercise the complete flow.