### PR TITLE
fix(ci): grant pull request comment access

### DIFF
--- a/.github/workflows/trusted-fork-tests.yml
+++ b/.github/workflows/trusted-fork-tests.yml
@@ -29,8 +29,7 @@ jobs:
     permissions:
       actions: write
       contents: write
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Authorize maintainer and dispatch PR revision
         uses: actions/github-script@v9
@@ -157,7 +156,7 @@ jobs:
       startsWith(github.event.workflow_run.head_branch, 'ci/pr-')
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     steps:
       - name: Update status comment
         uses: actions/github-script@v9


### PR DESCRIPTION
## Cause

[Trusted run 34211128307](https://github.com/magewirephp/magewire/actions/runs/34211128307) failed while creating the bot status comment. Its `POST /issues/292/comments` request returned `403 Resource not accessible by integration`.

Magewire has GitHub Issues disabled. The target is a pull-request conversation, but the workflow granted `issues: write` and only `pull-requests: read`. The API response lists `pull_requests=write` as the applicable write permission.

## Fix

Grant `pull-requests: write` to the dispatch and report jobs. This permits creation and later updates of the bot-owned PR status comment. No trust or execution behavior changes.

## Verification

- `actionlint .github/workflows/trusted-fork-tests.yml`
- YAML parse
- Embedded `github-script` JavaScript syntax check
- `git diff --check`

After merge, add a new `/test` comment to PR #292.