### PR TITLE
fix(ci): dispatch trusted workflow from main

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,12 @@ name: 'Playwright (Mage-OS + Hyvä)'
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: 'Optional commit SHA to test instead of the workflow ref.'
+        required: false
+        type: string
+        default: ''
     secrets:
       HYVA_COMPOSER_REPO_URL:
         required: true
@@ -26,7 +32,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: playwright-${{ github.ref }}
+  group: playwright-${{ inputs.checkout_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -105,6 +111,7 @@ jobs:
       - name: Checkout module (the PR code)
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.checkout_ref }}
           path: magewire-src
           persist-credentials: false
 

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -14,12 +14,18 @@ name: 'Production build'
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: 'Optional commit SHA to test instead of the workflow ref.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
 
 concurrency:
-  group: production-build-${{ github.ref }}
+  group: production-build-${{ inputs.checkout_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -84,6 +90,7 @@ jobs:
       - name: Checkout module (the PR code)
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.checkout_ref }}
           path: magewire-src
 
       - name: Setup PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,25 @@
 name: 'Tests'
 
+run-name: >-
+  ${{ inputs.trusted_pr_number != '' &&
+  format('Trusted fork PR #{0} @ {1}', inputs.trusted_pr_number, inputs.checkout_ref) ||
+  github.event.pull_request.title ||
+  github.event.head_commit.message ||
+  'Tests' }}
+
 on:
   workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: 'Optional commit SHA to test instead of the workflow ref.'
+        required: false
+        type: string
+        default: ''
+      trusted_pr_number:
+        description: 'Fork PR number requiring environment approval.'
+        required: false
+        type: string
+        default: ''
   push:
     branches:
       - main
@@ -35,7 +53,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: tests-${{ github.ref }}
+  group: tests-${{ inputs.trusted_pr_number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -43,10 +61,14 @@ jobs:
   unit-tests:
     name: 'Unit tests'
     uses: ./.github/workflows/unit-tests.yml
+    with:
+      checkout_ref: ${{ inputs.checkout_ref }}
 
   production-build:
     name: 'Production build'
     uses: ./.github/workflows/production-build.yml
+    with:
+      checkout_ref: ${{ inputs.checkout_ref }}
 
   approve-trusted-playwright:
     name: 'Approve fork Playwright'
@@ -54,13 +76,14 @@ jobs:
     # GitHub creates a missing environment without protection rules.
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      startsWith(github.ref, 'refs/heads/ci/pr-')
+      inputs.trusted_pr_number != '' &&
+      inputs.checkout_ref != ''
     runs-on: ubuntu-latest
     environment:
       name: trusted-fork-tests
     steps:
       - name: Record approval
-        run: echo "Approved private Playwright tests for $GITHUB_SHA."
+        run: echo "Approved private Playwright tests for ${{ inputs.checkout_ref }}."
 
   playwright:
     name: 'Playwright'
@@ -71,8 +94,10 @@ jobs:
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'workflow_dispatch' &&
-      !startsWith(github.ref, 'refs/heads/ci/pr-'))
+      inputs.trusted_pr_number == '')
     uses: ./.github/workflows/playwright.yml
+    with:
+      checkout_ref: ${{ inputs.checkout_ref }}
     secrets:
       HYVA_COMPOSER_REPO_URL: ${{ secrets.HYVA_COMPOSER_REPO_URL }}
       HYVA_COMPOSER_AUTH_TOKEN: ${{ secrets.HYVA_COMPOSER_AUTH_TOKEN }}
@@ -82,6 +107,8 @@ jobs:
     needs: approve-trusted-playwright
     if: needs.approve-trusted-playwright.result == 'success'
     uses: ./.github/workflows/playwright.yml
+    with:
+      checkout_ref: ${{ inputs.checkout_ref }}
     secrets:
       HYVA_COMPOSER_REPO_URL: ${{ secrets.HYVA_COMPOSER_REPO_URL }}
       HYVA_COMPOSER_AUTH_TOKEN: ${{ secrets.HYVA_COMPOSER_AUTH_TOKEN }}

--- a/.github/workflows/trusted-fork-tests.yml
+++ b/.github/workflows/trusted-fork-tests.yml
@@ -1,9 +1,10 @@
 name: 'Trusted fork tests'
 
 # Fork pull_request workflows intentionally receive no repository secrets. This
-# privileged broker mirrors an exact fork revision to an internal CI ref, but it
-# never checks out or executes contributor code. The private Playwright job is
-# released only after approval through the trusted-fork-tests environment.
+# privileged broker makes an exact fork revision reachable through an internal
+# CI ref, but dispatches the trusted workflow definition from main and never
+# executes contributor code itself. The private Playwright job is released only
+# after approval through the trusted-fork-tests environment.
 on:
   pull_request_target:
     branches: [main]
@@ -11,7 +12,7 @@ on:
   workflow_run:
     workflows: ['Tests']
     types: [completed]
-    branches: ['ci/pr-*']
+    branches: [main]
 
 permissions: {}
 
@@ -154,10 +155,14 @@ jobs:
               await github.rest.actions.createWorkflowDispatch({
                 ...context.repo,
                 workflow_id: 'tests.yml',
-                ref: branch,
+                ref: 'main',
+                inputs: {
+                  checkout_ref: pull.head.sha,
+                  trusted_pr_number: String(pull.number),
+                },
               });
 
-              const runsUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/tests.yml?query=${encodeURIComponent(`branch:${branch}`)}`;
+              const runsUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/tests.yml?query=${encodeURIComponent('branch:main event:workflow_dispatch')}`;
               await setStatus([
                 '### Trusted fork tests',
                 '',
@@ -168,7 +173,7 @@ jobs:
                 `[Review and follow the workflow run](${runsUrl})`,
               ]);
 
-              core.notice(`Dispatched Tests for PR #${pull.number} at ${pull.head.sha} via ${branch}.`);
+              core.notice(`Dispatched the main Tests workflow for PR #${pull.number} at ${pull.head.sha}.`);
             } catch (error) {
               await setStatus([
                 '### Trusted fork tests',
@@ -184,8 +189,7 @@ jobs:
     name: 'Report trusted result'
     if: >-
       github.event_name == 'workflow_run' &&
-      github.event.workflow_run.event == 'workflow_dispatch' &&
-      startsWith(github.event.workflow_run.head_branch, 'ci/pr-')
+      github.event.workflow_run.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -196,30 +200,33 @@ jobs:
         with:
           script: |
             const run = context.payload.workflow_run;
-            const match = /^ci\/pr-(\d+)$/.exec(run.head_branch);
+            const match = /^Trusted fork PR #(\d+) @ ([0-9a-f]{40})$/.exec(run.display_title);
 
             if (!match) {
-              core.notice(`Ignoring unrecognized trusted CI ref ${run.head_branch}.`);
-              return;
-            }
-
-            try {
-              const { data: current } = await github.rest.git.getRef({
-                ...context.repo,
-                ref: `heads/${run.head_branch}`,
-              });
-
-              if (current.object.sha !== run.head_sha) {
-                core.notice(`Ignoring stale result for ${run.head_sha}; ${run.head_branch} now points to ${current.object.sha}.`);
-                return;
-              }
-            } catch (error) {
-              if (error.status !== 404) throw error;
-              core.notice(`Ignoring result because ${run.head_branch} no longer exists.`);
+              core.notice(`Ignoring workflow dispatch named ${run.display_title}.`);
               return;
             }
 
             const pullNumber = Number(match[1]);
+            const testedSha = match[2];
+            const branch = `ci/pr-${pullNumber}`;
+
+            try {
+              const { data: current } = await github.rest.git.getRef({
+                ...context.repo,
+                ref: `heads/${branch}`,
+              });
+
+              if (current.object.sha !== testedSha) {
+                core.notice(`Ignoring stale result for ${testedSha}; ${branch} now points to ${current.object.sha}.`);
+                return;
+              }
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              core.notice(`Ignoring result because ${branch} no longer exists.`);
+              return;
+            }
+
             const marker = '<!-- trusted-fork-tests -->';
             const comments = await github.paginate(github.rest.issues.listComments, {
               ...context.repo,
@@ -236,8 +243,8 @@ jobs:
               return;
             }
 
-            const shortSha = run.head_sha.slice(0, 7);
-            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${run.head_sha}`;
+            const shortSha = testedSha.slice(0, 7);
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${testedSha}`;
             let summary;
 
             if (run.conclusion === 'success') {

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,12 +2,18 @@ name: 'Unit tests'
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: 'Optional commit SHA to test instead of the workflow ref.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
 
 concurrency:
-  group: unit-tests-${{ github.ref }}
+  group: unit-tests-${{ inputs.checkout_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -19,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Security fix

The first live run on PR #292 exposed a workflow-definition trust bug. Dispatching `tests.yml` with `ref: ci/pr-292` caused GitHub to load both the source and workflow YAML from the older fork commit, so its pre-gate `tests.yml` started Playwright immediately.

Run 34216974756 was cancelled before Composer auth configuration or PR-controlled code execution.

## Correction

- Always dispatch `tests.yml` from `main`.
- Pass the immutable fork head SHA and PR number as workflow inputs.
- Keep the Environment approval gate in the trusted `main` workflow definition.
- Pass the SHA only to checkout in Unit, Production, and Playwright reusable workflows.
- Key concurrency by PR instead of the shared `main` ref.
- Encode PR number and tested SHA in the run name for safe final-status reporting.
- Ignore stale results when the PR ref has moved.

## Environment prerequisite

Before merging, add `main` to the allowed deployment branches for `trusted-fork-tests`. The corrected approval job runs from `main`; the existing `ci/pr-*` policy will reject it. Keep the required reviewer and self-review prevention enabled.

## Verification

- Full `actionlint`
- YAML parse for all workflows
- Embedded `github-script` JavaScript syntax check
- `git diff --check`
- Confirmed every reusable workflow checkout consumes the immutable `checkout_ref`

After the environment allows `main`, mark ready, merge, and close/reopen PR #292 again.