### PR TITLE
Double-encode entities in wire:* root attributes

### DIFF
--- a/src/Helper/Functions.php
+++ b/src/Helper/Functions.php
@@ -49,10 +49,12 @@ class Functions
 
     public function escapeStringForHtml($subject): string
     {
-        if (is_string($subject) || is_numeric($subject)) {
-            return $this->escape->escapeHtml($subject);
+        if (!is_string($subject) && !is_numeric($subject)) {
+            $subject = $this->serializer->serialize($subject);
         }
 
-        return $this->escape->escapeHtml($this->serializer->serialize($subject));
+        // Escaper::escapeHtml keeps existing entities (double_encode=false), which turns serialized
+        // data containing e.g. `&quot;` into invalid JSON once the browser decodes the attribute.
+        return htmlspecialchars((string)$subject, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 }


### PR DESCRIPTION
We had problems with product attributes like size = `12"` in the combination with Amasty free gift which encodes the full cart in JSON. But magewire seems the root cause here. 

We are using Magento 2.4.8-p5 and Hyvä Checkout 1.3.13

Claude's analysis:

```
escapeStringForHtml() escapes the serialized component data with Escaper::escapeHtml(), which calls htmlspecialchars() with double_encode=false and therefore leaves existing entities untouched.

Component data that already contains an HTML entity, e.g. a formatted configurable option value like `12&quot; (30 cm)` for an inch size, is serialized to JSON and rendered as `&quot;` inside wire:initial-data. The browser decodes it to a raw quote inside the JSON string, JSON.parse() throws and the Magewire bootstrap of the whole page aborts ($wire is undefined in every component).

Encode with double_encode=true so that any data round-trips through the attribute.
```